### PR TITLE
Fix typo and row/col mix-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ $ ./build/2048.out
 * Game board will follow the following structure:
 
 ```
-'x' => x-axis OR the horizotal line OR rows
-'y' => y-axis OR the vertical line OR columns
+'x' => x-axis OR the horizontal line OR columns
+'y' => y-axis OR the vertical line OR rows
 ```
 
 ### For example (zero-indexed)


### PR DESCRIPTION
Hi,

I think you've mixed up row/columns there - the x-axis, or horizontal line, would specify the column, not the row (and similarly for the y-axis).

Cheers :)