### PR TITLE
Fixes issue #9, re: use of bold_on, bold_off

### DIFF
--- a/color.h
+++ b/color.h
@@ -5,27 +5,29 @@
 
 namespace Color {
     enum Code {
-        FG_DEFAULT = 39,
-        FG_BLACK = 30,
-        FG_RED = 31,
-        FG_GREEN = 32,
-        FG_YELLOW = 33,
-        FG_BLUE = 34,
-        FG_MAGENTA = 35,
-        FG_CYAN = 36,
-        FG_LIGHT_GRAY = 37,
-        FG_DARK_GRAY = 90,
-        FG_LIGHT_RED = 91,
-        FG_LIGHT_GREEN = 92,
-        FG_LIGHT_YELLOW = 93,
-        FG_LIGHT_BLUE = 94,
-        FG_LIGHT_MAGENTA = 95,
-        FG_LIGHT_CYAN = 96,
-        FG_WHITE = 97,
-        BG_RED = 41,
-        BG_GREEN = 42,
+        BOLD = 1,
+        RESET = 0,
         BG_BLUE = 44,
-        BG_DEFAULT = 49
+        BG_DEFAULT = 49,
+        BG_GREEN = 42,
+        BG_RED = 41,
+        FG_BLACK = 30,
+        FG_BLUE = 34,
+        FG_CYAN = 36,
+        FG_DARK_GRAY = 90,
+        FG_DEFAULT = 39,
+        FG_GREEN = 32,
+        FG_LIGHT_BLUE = 94,
+        FG_LIGHT_CYAN = 96,
+        FG_LIGHT_GRAY = 37,
+        FG_LIGHT_GREEN = 92,
+        FG_LIGHT_MAGENTA = 95,
+        FG_LIGHT_RED = 91,
+        FG_LIGHT_YELLOW = 93,
+        FG_MAGENTA = 35,
+        FG_RED = 31,
+        FG_WHITE = 97,
+        FG_YELLOW = 33,
     };
 
     class Modifier {
@@ -42,6 +44,8 @@ namespace Color {
 
 }
 
+static Color::Modifier bold_off(Color::RESET);
+static Color::Modifier bold_on(Color::BOLD);
 static Color::Modifier def(Color::FG_DEFAULT);
 static Color::Modifier red(Color::FG_RED);
 static Color::Modifier green(Color::FG_GREEN);

--- a/global.cpp
+++ b/global.cpp
@@ -47,11 +47,3 @@ void endl(int n) {
 void clearScreen() {
     system("clear");
 };
-
-std::ostream &bold_on(std::ostream &os) {
-    return os << "\e[1m";
-}
-
-std::ostream &bold_off(std::ostream &os) {
-    return os << "\e[0m";
-}

--- a/global.h
+++ b/global.h
@@ -14,7 +14,4 @@ void endl(int n=1);
 
 void clearScreen();
 
-std::ostream &bold_on();
-std::ostream &bold_off();
-
 #endif


### PR DESCRIPTION
The discussion on issue #9 had a different solution, but I thought this way fit better than a macro.

The bug (re: 1's) was observed on macOS, where the output stream got "true" (therefore: 1's)

Thanks for writing this project. P.S. Love the vim keys, but would be nice if arrows worked.