### PR TITLE
Fix: showScores: return statement from void

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -65,7 +65,6 @@ void Menu::showScores() {
   Scoreboard s;
   s.printScore();
   s.printStats();
-  return;
 }
 
 void drawAscii() {


### PR DESCRIPTION
Removed unneeded return statement from void function.  
_(This was previously omitted from last PR. This is a new PR because less risk of messing up git repository)_