### PR TITLE
Fix: Wrap parameters and variables around new datatype: point2D_t

### DIFF
--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -3,6 +3,7 @@
 
 #include "color.hpp"
 #include "global.hpp"
+#include "point2d.hpp"
 #include "scores.hpp"
 #include "statistics.hpp"
 #include <chrono>
@@ -48,22 +49,32 @@ private:
 class GameBoard {
   std::vector<Tile> board;
   ull playsize{0};
+  int point2D_to_1D_index(point2D_t pt) const {
+    int x, y;
+    std::tie(x, y) = pt.get();
+    return x + playsize * y;
+  }
 
 public:
   GameBoard() = default;
   explicit GameBoard(ull playsize)
       : playsize{playsize}, board{std::vector<Tile>(playsize * playsize)} {}
-  Tile getTile(int x, int y) const { return board[x + playsize * y]; }
-  void setTile(int x, int y, Tile tile) { board[x + playsize * y] = tile; }
-  ull getTileValue(int x, int y) const { return board[x + playsize * y].value; }
-  void setTileValue(int x, int y, ull value) {
-    board[x + playsize * y].value = value;
+
+  Tile getTile(point2D_t pt) const { return board[point2D_to_1D_index(pt)]; }
+  void setTile(point2D_t pt, Tile tile) {
+    board[point2D_to_1D_index(pt)] = tile;
   }
-  bool getTileBlocked(int x, int y) const {
-    return board[x + playsize * y].blocked;
+  ull getTileValue(point2D_t pt) const {
+    return board[point2D_to_1D_index(pt)].value;
   }
-  void setTileBlocked(int x, int y, bool blocked) {
-    board[x + playsize * y].blocked = blocked;
+  void setTileValue(point2D_t pt, ull value) {
+    board[point2D_to_1D_index(pt)].value = value;
+  }
+  bool getTileBlocked(point2D_t pt) const {
+    return board[point2D_to_1D_index(pt)].blocked;
+  }
+  void setTileBlocked(point2D_t pt, bool blocked) {
+    board[point2D_to_1D_index(pt)].blocked = blocked;
   }
   void clearGameBoard() { board = std::vector<Tile>(playsize * playsize); }
   int getPlaySize() const { return playsize; }
@@ -93,15 +104,15 @@ private:
 
   void initialiseContinueBoardArray();
   bool addTile();
-  void collectFreeTiles(std::vector<std::tuple<int, int>> &freeTiles);
+  std::vector<point2D_t> collectFreeTiles();
   void drawBoard();
   void drawScoreBoard(std::ostream &out_stream);
   void input(KeyInputErrorStatus err = STATUS_INPUT_VALID);
   bool canMove();
-  bool testAdd(int, int, ull);
+  bool testAdd(point2D_t pt, ull);
   void unblockTiles();
   void decideMove(Directions);
-  void move(int, int, int, int);
+  void move(point2D_t pt, point2D_t pt_offset);
   void statistics();
   void saveStats();
   void saveScore();

--- a/src/headers/point2d.hpp
+++ b/src/headers/point2d.hpp
@@ -7,7 +7,7 @@ class point2D_t {
   // Simple {x,y} datastructure = std::tuple<int, int>...
   using point_datatype_t = typename std::tuple<int, int>;
   point_datatype_t point_vector{};
-  point2D_t(const point_datatype_t pt) : point_vector{pt} {}
+  explicit point2D_t(const point_datatype_t pt) : point_vector{pt} {}
 
 public:
   enum class PointCoord { COORD_X, COORD_Y };

--- a/src/headers/point2d.hpp
+++ b/src/headers/point2d.hpp
@@ -1,0 +1,56 @@
+#ifndef POINT_2D_H
+#define POINT_2D_H
+
+#include <tuple>
+
+class point2D_t {
+  // Simple {x,y} datastructure = std::tuple<int, int>...
+  using point_datatype_t = typename std::tuple<int, int>;
+  point_datatype_t point_vector{};
+  point2D_t(const point_datatype_t pt) : point_vector{pt} {}
+
+public:
+  enum class PointCoord { COORD_X, COORD_Y };
+
+  point2D_t() = default;
+  point2D_t(const int x, const int y) : point2D_t(std::make_tuple(x, y)) {}
+
+  template<PointCoord dimension>
+  int get() const {
+    return std::get<static_cast<int>(dimension)>(point_vector);
+  }
+  template<PointCoord dimension>
+  void set(int value) {
+    std::get<static_cast<int>(dimension)>(point_vector) = value;
+  }
+  point_datatype_t get() const { return point_vector; }
+  void set(point_datatype_t value) { point_vector = value; }
+
+  void set(const int x, const int y) { set(std::make_tuple(x, y)); }
+
+  point2D_t &operator+=(const point2D_t &pt) {
+    this->point_vector = std::make_tuple(
+        get<PointCoord::COORD_X>() + pt.get<PointCoord::COORD_X>(),
+        get<PointCoord::COORD_Y>() + pt.get<PointCoord::COORD_Y>());
+    return *this;
+  }
+
+  point2D_t &operator-=(const point2D_t &pt) {
+    this->point_vector = std::make_tuple(
+        get<PointCoord::COORD_X>() - pt.get<PointCoord::COORD_X>(),
+        get<PointCoord::COORD_Y>() - pt.get<PointCoord::COORD_Y>());
+    return *this;
+  }
+};
+
+inline point2D_t operator+(point2D_t l, const point2D_t &r) {
+  l += r;
+  return l;
+}
+
+inline point2D_t operator-(point2D_t l, const point2D_t &r) {
+  l -= r;
+  return l;
+}
+
+#endif


### PR DESCRIPTION
[As title description]

This PR was hinted to arrive from [PR:69](https://github.com/plibither8/2048.cpp/pull/69/commits/0c2e4a02a7d13684546c6cfc471b0b701360687f#diff-18513665750ef5adf42b5ec29e14162eR134).
 This greatly helps developers understand context for parameters in interfaces around the codebase.
