### PR TITLE
Fix: reduce std::cout usage

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -186,35 +186,39 @@ void Game::drawScoreBoard(std::ostream &out_stream) const {
 }
 
 void Game::input(KeyInputErrorStatus err) {
+  constexpr auto input_commands_text = u8R"(
+  W or K or ↑ => Up
+  A or H or ← => Left
+  S or J or ↓ => Down
+  D or L or → => Right
+  Z or P => Save
 
-  using namespace Keypress::Code;
-  char c;
+  Press the keys to start and continue.
 
-  std::cout << "  W or K or \u2191 => Up";
-  newline();
-  std::cout << "  A or H or \u2190 => Left";
-  newline();
-  std::cout << "  S or J or \u2193 => Down";
-  newline();
-  std::cout << "  D or L or \u2192 => Right";
-  newline();
-  std::cout << "  Z or P => Save";
-  newline(2);
-  std::cout << "  Press the keys to start and continue.";
-  newline();
+)";
+
+  constexpr auto invalid_prompt_text = "Invalid input. Please try again.";
+  constexpr auto sp = "  ";
+  std::ostringstream str_os;
+  std::ostringstream invalid_prompt_richtext;
+  invalid_prompt_richtext << red << sp << invalid_prompt_text << def << "\n\n";
+
+  str_os << input_commands_text;
 
   if (err == KeyInputErrorStatus::STATUS_INPUT_ERROR) {
-    std::cout << red << "  Invalid input. Please try again." << def;
-    newline(2);
+    str_os << invalid_prompt_richtext.str();
   }
+  std::cout << str_os.str();
 
+  using namespace Keypress::Code;
+
+  char c;
   getInput(c);
 
   if (c == CODE_ANSI_TRIGGER_1) {
     getInput(c);
     if (c == CODE_ANSI_TRIGGER_2) {
       getInput(c);
-      newline(4);
       switch (c) {
       case CODE_ANSI_UP:
         decideMove(UP);
@@ -229,12 +233,8 @@ void Game::input(KeyInputErrorStatus err) {
         decideMove(LEFT);
         return;
       }
-    } else {
-      newline(4);
     }
   }
-
-  newline(4);
 
   switch (toupper(c)) {
 
@@ -398,7 +398,6 @@ void Game::playGame(ContinueStatus cont) {
     newline(2);
     saveScore();
   }
-
 }
 
 ull Game::setBoardSize() {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -288,22 +288,33 @@ void Game::decideMove(Directions d) {
 }
 
 void Game::statistics() const {
+  constexpr auto stats_title_text = "STATISTICS";
+  constexpr auto divider_text = "──────────";
+  constexpr auto stats_attributes_text = {
+      "Final score:", "Largest Tile:", "Number of moves:", "Time taken:"};
+  constexpr auto sp = "  ";
 
-  std::cout << yellow << "  STATISTICS" << def;
-  newline();
-  std::cout << yellow << "  ──────────" << def;
-  newline();
-  std::cout << "  Final score:       " << bold_on << gamePlayBoard.score
-            << bold_off;
-  newline();
-  std::cout << "  Largest Tile:      " << bold_on << gamePlayBoard.largestTile
-            << bold_off;
-  newline();
-  std::cout << "  Number of moves:   " << bold_on << moveCount << bold_off;
-  newline();
-  std::cout << "  Time taken:        " << bold_on << secondsFormat(duration)
-            << bold_off;
-  newline();
+  auto data_stats = std::array<std::string, stats_attributes_text.size()>{};
+  data_stats = {std::to_string(gamePlayBoard.score),
+                std::to_string(gamePlayBoard.largestTile),
+                std::to_string(moveCount), secondsFormat(duration)};
+
+  std::ostringstream stats_richtext;
+  stats_richtext << yellow << sp << stats_title_text << def << "\n";
+  stats_richtext << yellow << sp << divider_text << def << "\n";
+
+  auto counter{0};
+  const auto populate_stats_info = [data_stats, &counter,
+                                    &stats_richtext](const std::string) {
+    stats_richtext << sp << std::left << std::setw(19)
+                   << std::begin(stats_attributes_text)[counter] << bold_on
+                   << std::begin(data_stats)[counter] << bold_off << "\n";
+    counter++;
+  };
+  std::for_each(std::begin(stats_attributes_text),
+                std::end(stats_attributes_text), populate_stats_info);
+
+  std::cout << stats_richtext.str();
 }
 
 void Game::saveStats() const {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -360,10 +360,27 @@ void Game::saveState() const {
 }
 
 void Game::playGame(ContinueStatus cont) {
+  constexpr auto state_saved_text =
+      "The game has been saved. Feel free to take a break.";
+  constexpr auto win_game_text = "You win! Congratulations!";
+  constexpr auto lose_game_text = "Game over! You lose.";
+  constexpr auto sp = "  ";
+
+  std::ostringstream state_saved_richtext;
+  state_saved_richtext << green << bold_on << sp << state_saved_text << def
+                       << bold_off << "\n\n";
+  std::ostringstream win_richtext;
+  win_richtext << green << bold_on << sp << win_game_text << def << bold_off
+               << "\n\n\n";
+
+  std::ostringstream lose_richtext;
+  lose_richtext << red << bold_on << sp << lose_game_text << def << bold_off
+                << "\n\n\n";
 
   auto startTime = std::chrono::high_resolution_clock::now();
 
   while (true) {
+    std::ostringstream str_os;
     if (gamePlayBoard.moved) {
       gamePlayBoard.addTile();
       moveCount++;
@@ -377,12 +394,10 @@ void Game::playGame(ContinueStatus cont) {
     }
 
     if (stateSaved) {
-      std::cout << green << bold_on
-                << "  The game has been saved. Feel free to take a break."
-                << def << bold_off;
-      newline(2);
+      str_os << state_saved_richtext.str();
       stateSaved = false;
     }
+    std::cout << str_os.str();
     input();
     gamePlayBoard.unblockTiles();
   }
@@ -391,16 +406,13 @@ void Game::playGame(ContinueStatus cont) {
   std::chrono::duration<double> elapsed = finishTime - startTime;
   duration = elapsed.count();
 
-  const auto msg = gamePlayBoard.win ? "  You win! Congratulations! " :
-                                       "  Game over! You lose.";
-
+  std::ostringstream str_os;
   if (gamePlayBoard.win) {
-    std::cout << green << bold_on << msg << def << bold_off;
-    newline(3);
+    str_os << win_richtext.str();
   } else {
-    std::cout << red << bold_on << msg << def << bold_off;
-    newline(3);
+    str_os << lose_richtext.str();
   }
+  std::cout << str_os.str();
 
   if (gamePlayBoard.getPlaySize() == COMPETITION_GAME_BOARD_PLAY_SIZE &&
       cont == ContinueStatus::STATUS_END_GAME) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -412,32 +412,47 @@ void Game::playGame(ContinueStatus cont) {
 }
 
 ull Game::setBoardSize() {
+  constexpr auto invalid_prompt_text = {
+      "Invalid input. Gameboard size should range from ", " to ", "."};
+  constexpr auto no_save_found_text =
+      "No saved game found. Starting a new game.";
+  constexpr auto board_size_prompt_text =
+      "Enter gameboard size (NOTE: Scores and statistics will be saved only for the 4x4 gameboard): ";
+  constexpr auto sp = "  ";
 
   enum { MIN_GAME_BOARD_PLAY_SIZE = 3, MAX_GAME_BOARD_PLAY_SIZE = 10 };
+
+  std::ostringstream str_os;
+  std::ostringstream error_prompt_richtext;
+  error_prompt_richtext << red << sp << std::begin(invalid_prompt_text)[0]
+                        << MIN_GAME_BOARD_PLAY_SIZE
+                        << std::begin(invalid_prompt_text)[1]
+                        << MAX_GAME_BOARD_PLAY_SIZE
+                        << std::begin(invalid_prompt_text)[2] << def << "\n\n";
+  std::ostringstream no_save_richtext;
+  no_save_richtext << red << bold_on << sp << no_save_found_text << def
+                   << bold_off << "\n\n";
+  std::ostringstream board_size_prompt_richtext;
+  board_size_prompt_richtext << bold_on << sp << board_size_prompt_text
+                             << bold_off;
+
   bool err = false;
   ull userInput_PlaySize{0};
+
   while ((userInput_PlaySize < MIN_GAME_BOARD_PLAY_SIZE ||
           userInput_PlaySize > MAX_GAME_BOARD_PLAY_SIZE)) {
     clearScreen();
     drawAscii();
 
     if (err) {
-      std::cout << red << "  Invalid input. Gameboard size should range from "
-                << MIN_GAME_BOARD_PLAY_SIZE << " to "
-                << MAX_GAME_BOARD_PLAY_SIZE << "." << def;
-      newline(2);
+      str_os << error_prompt_richtext.str();
     } else if (noSave) {
-      std::cout << red << bold_on
-                << "  No saved game found. Starting a new game." << def
-                << bold_off;
-      newline(2);
+      str_os << no_save_richtext.str();
       noSave = false;
     }
 
-    std::cout << bold_on
-              << "  Enter gameboard size (NOTE: Scores and statistics will be "
-                 "saved only for the 4x4 gameboard): "
-              << bold_off;
+    str_os << board_size_prompt_richtext.str();
+    std::cout << str_os.str();
 
     std::cin >> userInput_PlaySize;
     std::cin.clear();

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -174,7 +174,7 @@ std::string GameBoard::drawSelf() const {
   }
 
   str_os << std::get<BASE_BAR>(vertibar).str();
-  str_os << "\n\n\n";
+  str_os << "\n";
   return str_os.str();
 }
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -99,6 +99,8 @@ void drawAscii() {
         /\\\\\\\\\\\\\\\   \///\\\\\\\/              \/\\\      \///\\\\\\\\\/
         \///////////////      \///////                \///         \/////////
   )";
-  std::cout << green << bold_on << title_card_2048 << bold_off << def;
-  newline(3);
+  std::ostringstream title_card_richtext;
+  title_card_richtext << green << bold_on << title_card_2048 << bold_off << def;
+  title_card_richtext << "\n\n\n";
+  std::cout << title_card_richtext.str();
 }

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,21 +1,28 @@
 #include "menu.hpp"
 
 void Menu::startMenu(int err) {
+  constexpr auto greetings_text = "Welcome to ";
+  constexpr auto gamename_text = "2048!";
+  constexpr auto sp = "  ";
+
+  std::ostringstream str_os;
+  std::ostringstream title_richtext;
+  title_richtext << bold_on << sp << greetings_text << blue << gamename_text
+                 << def << bold_off << "\n";
+
+  constexpr auto menu_entry_text = R"(
+          1. Play a New Game
+          2. Continue Previous Game
+          3. View Highscores and Statistics
+          4. Exit
+
+)";
 
   clearScreen();
-
   drawAscii();
-  std::cout << bold_on << "  Welcome to " << blue << "2048!" << def << bold_off;
-  newline(2);
-  std::cout << "          1. Play a New Game";
-  newline();
-  std::cout << "          2. Continue Previous Game";
-  newline();
-  std::cout << "          3. View Highscores and Statistics";
-  newline();
-  std::cout << "          4. Exit";
-  newline(2);
-
+  str_os << title_richtext.str();
+  str_os << menu_entry_text;
+  std::cout << str_os.str();
   input(err);
 }
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -27,13 +27,22 @@ void Menu::startMenu(int err) {
 }
 
 void Menu::input(int err) {
+  constexpr auto err_input_text = "Invalid input. Please try again.";
+  constexpr auto prompt_choice_text = "Enter Choice: ";
+  constexpr auto sp = "  ";
+
+  std::ostringstream str_os;
+  std::ostringstream err_input_richtext;
+  err_input_richtext << red << sp << err_input_text << def << "\n\n";
+  std::ostringstream prompt_choice_richtext;
+  prompt_choice_richtext << sp << prompt_choice_text;
 
   if (err) {
-    std::cout << red << "  Invalid input. Please try again." << def;
-    newline(2);
+    str_os << err_input_richtext.str();
   }
 
-  std::cout << "  Enter Choice: ";
+  str_os << prompt_choice_richtext.str();
+  std::cout << str_os.str();
   char c;
   std::cin >> c;
 

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -185,7 +185,10 @@ void Scoreboard::readFile() {
     scoreList.push_back(bufferScore);
   };
 
-  std::sort(scoreList.begin(), scoreList.end(), compare);
+  const auto predicate = [](const Score a, const Score b) {
+    return a.score > b.score;
+  };
+  std::sort(scoreList.begin(), scoreList.end(), predicate);
 }
 
 void Scoreboard::save() {

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -27,64 +27,72 @@ void Scoreboard::writeToFile() {
 }
 
 void Scoreboard::printScore() {
+  constexpr auto no_save_text = "No saved scores.";
+  constexpr auto score_attributes_text = {
+      "No.", "Name", "Score", "Won?", "Moves", "Largest Tile", "Duration"};
+  constexpr auto header_border_text =
+      "┌─────┬────────────────────┬──────────┬──────┬───────┬──────────────┬──────────────┐";
+  constexpr auto mid_border_text =
+      "├─────┼────────────────────┼──────────┼──────┼───────┼──────────────┼──────────────┤";
+  constexpr auto bottom_border_text =
+      "└─────┴────────────────────┴──────────┴──────┴───────┴──────────────┴──────────────┘";
+  constexpr auto score_title_text = "SCOREBOARD";
+  constexpr auto divider_text = "──────────";
+  constexpr auto sp = "  ";
+
+  std::ostringstream str_os;
 
   readFile();
 
   clearScreen();
   drawAscii();
-  std::cout << green << bold_on << "  SCOREBOARD" << bold_off << def;
-  newline();
-  std::cout << green << bold_on << "  ──────────" << bold_off << def;
-  newline();
+  str_os << green << bold_on << sp << score_title_text << bold_off << def
+         << "\n";
+  str_os << green << bold_on << sp << divider_text << bold_off << def << "\n";
 
-  int size = scoreList.size();
+  const auto number_of_scores = scoreList.size();
+  if (number_of_scores) {
+    str_os << sp << header_border_text << "\n";
+    str_os << std::left;
+    str_os << sp << "│ " << bold_on << std::begin(score_attributes_text)[0]
+           << bold_off << " │ " << bold_on << std::setw(18)
+           << std::begin(score_attributes_text)[1] << bold_off << " │ "
+           << bold_on << std::setw(8) << std::begin(score_attributes_text)[2]
+           << bold_off << " │ " << bold_on
+           << std::begin(score_attributes_text)[3] << bold_off << " │ "
+           << bold_on << std::begin(score_attributes_text)[4] << bold_off
+           << " │ " << bold_on << std::begin(score_attributes_text)[5]
+           << bold_off << " │ " << bold_on << std::setw(12)
+           << std::begin(score_attributes_text)[6] << bold_off << " │"
+           << "\n";
+    str_os << std::right;
+    str_os << sp << mid_border_text << "\n";
 
-  for (int i = size - 1; i >= 0; i--) {
+    auto counter{1};
+    const auto print_score_stat = [&counter, &str_os](const Score i) {
+      constexpr auto number_of_fields = 7;
+      auto data_stats = std::array<std::string, number_of_fields>{};
+      data_stats = {std::to_string(counter),     i.name,
+                    std::to_string(i.score),     i.win ? "Yes" : "No",
+                    std::to_string(i.moveCount), std::to_string(i.largestTile),
+                    secondsFormat(i.duration)};
+      str_os << sp << "│ " << std::setw(2) << data_stats[0] << ". │ "
+             << std::left << std::setw(18) << data_stats[1] << std::right
+             << " │ " << std::setw(8) << data_stats[2] << " │ " << std::setw(4)
+             << data_stats[3] << " │ " << std::setw(5) << data_stats[4] << " │ "
+             << std::setw(12) << data_stats[5] << " │ " << std::setw(12)
+             << data_stats[6] << " │"
+             << "\n";
+      counter++;
+    };
 
-    std::string playerName = scoreList[i].name;
-    ull playerScore = scoreList[i].score;
-    std::string won = scoreList[i].win ? "Yes" : "No";
-    long long moveCount = scoreList[i].moveCount;
-    ull largestTile = scoreList[i].largestTile;
-    double duration = scoreList[i].duration;
-
-    if (i == size - 1) {
-      std::cout << "  "
-                   "┌─────┬────────────────────┬──────────┬──────┬───────┬─────"
-                   "─────────┬──────────────┐";
-      newline();
-      std::cout << "  │ " << bold_on << "No." << bold_off << " │ " << bold_on
-                << "Name" << bold_off << "               │ " << bold_on
-                << "Score" << bold_off << "    │ " << bold_on << "Won?"
-                << bold_off << " │ " << bold_on << "Moves" << bold_off << " │ "
-                << bold_on << "Largest Tile" << bold_off << " │ " << bold_on
-                << "Duration    " << bold_off << " │";
-      newline();
-      std::cout << "  "
-                   "├─────┼────────────────────┼──────────┼──────┼───────┼─────"
-                   "─────────┼──────────────┤";
-      newline();
-    }
-
-    std::cout << "  │ " << std::setw(2) << size - i << ". │ " << playerName;
-    padding(playerName);
-    std::cout << " │ " << std::setw(8) << playerScore << " │ " << std::setw(4)
-              << won << " │ " << std::setw(5) << moveCount << " │ "
-              << std::setw(12) << largestTile << " │ " << std::setw(12)
-              << secondsFormat(duration) << " │ ";
-    newline();
-  }
-
-  if (!size) {
-    std::cout << "  No saved scores.";
-    newline();
+    std::for_each(std::begin(scoreList), std::end(scoreList), print_score_stat);
+    str_os << sp << bottom_border_text << "\n";
   } else {
-    std::cout << "  "
-                 "└─────┴────────────────────┴──────────┴──────┴───────┴───────"
-                 "───────┴──────────────┘";
+    str_os << sp << no_save_text << "\n";
   }
-
-  newline(3);
+  str_os << "\n\n";
+  std::cout << str_os.str();
 }
 
 void Scoreboard::printStats() {

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -170,9 +170,13 @@ void Scoreboard::readFile() {
 }
 
 void Scoreboard::save() {
+  constexpr auto score_saved_text = "Score saved!";
+  constexpr auto sp = "  ";
+  std::ostringstream score_saved_richtext;
+  score_saved_richtext << green << bold_on << sp << score_saved_text << bold_off
+                       << def << "\n";
 
   prompt();
   writeToFile();
-  std::cout << green << bold_on << "  Score saved!" << bold_off << def;
-  newline();
+  std::cout << score_saved_richtext.str();
 }

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -5,9 +5,14 @@ bool compare(const Score &a, const Score &b) {
 };
 
 void Scoreboard::prompt() {
+  constexpr auto score_prompt_text =
+      "Please enter your name to save this score: ";
+  constexpr auto sp = "  ";
 
-  std::cout << bold_on
-            << "  Please enter your name to save this score: " << bold_off;
+  std::ostringstream score_prompt_richtext;
+  score_prompt_richtext << bold_on << sp << score_prompt_text << bold_off;
+
+  std::cout << score_prompt_richtext.str();
   std::cin >> name;
 }
 

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -88,43 +88,54 @@ void Scoreboard::printScore() {
 }
 
 void Scoreboard::printStats() {
+  constexpr auto stats_title_text = "STATISTICS";
+  constexpr auto divider_text = "──────────";
+  constexpr auto header_border_text = "┌────────────────────┬─────────────┐";
+  constexpr auto footer_border_text = "└────────────────────┴─────────────┘";
+  constexpr auto stats_attributes_text = {
+      "Best Score", "Game Count", "Number of Wins", "Total Moves Played",
+      "Total Duration"};
+  constexpr auto no_save_text = "No saved statistics.";
+  constexpr auto any_key_exit_text = "Press any key to exit: ";
+  constexpr auto sp = "  ";
 
   Stats stats;
+  std::ostringstream stats_richtext;
   if (stats.collectStatistics()) {
+    auto data_stats = std::array<std::string, stats_attributes_text.size()>{};
+    data_stats = {
+        std::to_string(stats.bestScore), std::to_string(stats.gameCount),
+        std::to_string(stats.winCount), std::to_string(stats.totalMoveCount),
+        secondsFormat(stats.totalDuration)};
 
-    std::cout << green << bold_on << "  STATISTICS" << bold_off << def;
-    newline();
-    std::cout << green << bold_on << "  ──────────" << bold_off << def;
-    newline();
-    std::cout << "  ┌────────────────────┬─────────────┐";
-    newline();
-    std::cout << "  │ " << bold_on << "Best Score        " << bold_off << " │ "
-              << std::setw(11) << stats.bestScore << " │";
-    newline();
-    std::cout << "  │ " << bold_on << "Game Count        " << bold_off << " │ "
-              << std::setw(11) << stats.gameCount << " │";
-    newline();
-    std::cout << "  │ " << bold_on << "Number of Wins    " << bold_off << " │ "
-              << std::setw(11) << stats.winCount << " │";
-    newline();
-    std::cout << "  │ " << bold_on << "Total Moves Played" << bold_off << " │ "
-              << std::setw(11) << stats.totalMoveCount << " │";
-    newline();
-    std::cout << "  │ " << bold_on << "Total Duration    " << bold_off << " │ "
-              << std::setw(11) << secondsFormat(stats.totalDuration) << " │";
-    newline();
-    std::cout << "  └────────────────────┴─────────────┘";
-    newline();
+    auto counter{0};
+    const auto populate_stats_info = [data_stats, &counter,
+                                      &stats_richtext](const std::string) {
+      stats_richtext << sp << "│ " << bold_on << std::left << std::setw(18)
+                     << std::begin(stats_attributes_text)[counter] << bold_off
+                     << " │ " << std::right << std::setw(11)
+                     << data_stats[counter] << " │"
+                     << "\n";
+      counter++;
+    };
+
+    stats_richtext << green << bold_on << sp << stats_title_text << bold_off
+                   << def << "\n";
+    stats_richtext << green << bold_on << sp << divider_text << bold_off << def
+                   << "\n";
+    stats_richtext << sp << header_border_text << "\n";
+    std::for_each(std::begin(stats_attributes_text),
+                  std::end(stats_attributes_text), populate_stats_info);
+    stats_richtext << sp << footer_border_text << "\n";
 
   } else {
-
-    std::cout << "  No saved statistics.";
-    newline();
+    stats_richtext << sp << no_save_text << "\n";
   }
 
-  newline(3);
+  stats_richtext << "\n\n\n";
+  stats_richtext << sp << any_key_exit_text;
 
-  std::cout << "  Press any key to exit: ";
+  std::cout << stats_richtext.str();
   char c;
   std::cin >> c;
   exit(EXIT_SUCCESS);


### PR DESCRIPTION
[This PR is intended to be squashed into one major commit.] :card_file_box: 
[The PR is unsquashed for now as individual commits help in reviewing changes and understanding the changes' history / timeline.] :mag: :watch: 

This PR refactors a lot of hard (magic) values and use of the global `std::cout` function for many string formatting tasks.
It is replaced with `std::ostringstream`.
This is to help with setting up testing in the near future.
This PR code-style (i.e. declaration of fixed values defined at the beginning of the function) is needed for when testing is added for each individual function in the future.

_N.B. `std::cin` usage has not been refactored in this PR. It will be done in a future PR._