### PR TITLE
Fix: Loading Saved Game Data

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -159,15 +159,11 @@ bool Game::load_game_stats_from_file(std::string filename) {
   return get_and_process_game_stats_string_data(stats);
 }
 
-void Game::initialiseContinueBoardArray() {
-  auto loaded_ok{false}, loaded_ok2{false};
-
-  loaded_ok = load_GameBoard_data_from_file("../data/previousGame");
-  loaded_ok2 = load_game_stats_from_file("../data/previousGameStats");
-
-  if (!loaded_ok || !loaded_ok2) {
-    noSave = true;
-  }
+bool Game::initialiseContinueBoardArray() {
+  constexpr auto gameboard_data_filename = "../data/previousGame";
+  constexpr auto game_stats_data_filename = "../data/previousGameStats";
+  return (load_GameBoard_data_from_file(gameboard_data_filename) &&
+          load_game_stats_from_file(game_stats_data_filename));
 }
 
 void Game::drawBoard() const {
@@ -553,11 +549,10 @@ void Game::continueGame() {
     bestScore = stats.bestScore;
   }
 
-  initialiseContinueBoardArray();
-
-  if (noSave) {
-    startGame();
-  } else {
+  if (initialiseContinueBoardArray()) {
     playGame(ContinueStatus::STATUS_CONTINUE);
+  } else {
+    noSave = true;
+    startGame();
   }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -50,14 +50,10 @@ Color::Modifier Tile::tileColor(ull value) {
   return colors[index];
 }
 
-int GetLines() {
-  int noOfLines = 0;
-  std::string tempLine;
-  std::ifstream stateFile("../data/previousGame");
-  while (std::getline(stateFile, tempLine, '\n')) {
-    noOfLines++;
-  }
-  stateFile.close();
+int GetLines(std::string filename) {
+  std::ifstream stateFile(filename);
+  using iter = std::istreambuf_iterator<char>;
+  const auto noOfLines = std::count(iter{stateFile}, iter{}, '\n');
   return noOfLines;
 }
 
@@ -115,7 +111,7 @@ std::vector<Tile> process_file_tile_string_data(std::vector<std::string> buf) {
 bool Game::load_GameBoard_data_from_file(std::string filename) {
   std::ifstream stateFile(filename);
   if (stateFile) {
-    const ull savedBoardPlaySize = GetLines();
+    const ull savedBoardPlaySize = GetLines(filename);
     const auto file_tile_data = get_file_tile_data(stateFile);
     const auto processed_tile_data =
         process_file_tile_string_data(file_tile_data);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -125,26 +125,47 @@ bool Game::load_GameBoard_data_from_file(std::string filename) {
   return false;
 }
 
-void Game::initialiseContinueBoardArray() {
-  std::string temp, tempLine;
-  auto loaded_ok{false};
-
-  loaded_ok = load_GameBoard_data_from_file("../data/previousGame");
-
-  if (loaded_ok) {
-    std::ifstream stats("../data/previousGameStats");
-    while (std::getline(stats, tempLine, '\n')) {
-      std::stringstream line(tempLine);
-      int k = 0;
-      while (std::getline(line, temp, ':')) {
-        if (k == 0)
+bool Game::get_and_process_game_stats_string_data(std::istream &stats_file) {
+  if (stats_file) {
+    for (std::string tempLine; std::getline(stats_file, tempLine);) {
+      enum GameStatsFieldIndex {
+        IDX_GAME_SCORE_VALUE,
+        IDX_GAME_MOVECOUNT,
+        MAX_NO_GAME_STATS_IDXS
+      };
+      std::istringstream line(tempLine);
+      auto idx_id{0};
+      for (std::string temp; std::getline(line, temp, ':'); idx_id++) {
+        switch (idx_id) {
+        case IDX_GAME_SCORE_VALUE:
           gamePlayBoard.score = std::stoi(temp);
-        else if (k == 1)
+          break;
+        case IDX_GAME_MOVECOUNT:
           gamePlayBoard.moveCount = std::stoi(temp) - 1;
-        k++;
+          break;
+        default:
+          // Error: No fields to process!
+          break;
+        }
       }
     }
-  } else {
+    return true;
+  }
+  return false;
+}
+
+bool Game::load_game_stats_from_file(std::string filename) {
+  std::ifstream stats(filename);
+  return get_and_process_game_stats_string_data(stats);
+}
+
+void Game::initialiseContinueBoardArray() {
+  auto loaded_ok{false}, loaded_ok2{false};
+
+  loaded_ok = load_GameBoard_data_from_file("../data/previousGame");
+  loaded_ok2 = load_game_stats_from_file("../data/previousGameStats");
+
+  if (!loaded_ok || !loaded_ok2) {
     noSave = true;
   }
 }

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -37,7 +37,6 @@ private:
   enum KeyInputErrorStatus { STATUS_INPUT_VALID = 0, STATUS_INPUT_ERROR = 1 };
   enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
 
-  bool load_GameBoard_data_from_file(std::string filename);
   bool get_and_process_game_stats_string_data(std::istream &stats_file);
   bool load_game_stats_from_file(std::string filename);
   bool initialiseContinueBoardArray();

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -37,6 +37,7 @@ private:
   enum KeyInputErrorStatus { STATUS_INPUT_VALID = 0, STATUS_INPUT_ERROR = 1 };
   enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
 
+  bool load_GameBoard_data_from_file(std::string filename);
   void initialiseContinueBoardArray();
   void drawBoard() const;
   void drawScoreBoard(std::ostream &out_stream) const;

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -38,6 +38,8 @@ private:
   enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
 
   bool load_GameBoard_data_from_file(std::string filename);
+  bool get_and_process_game_stats_string_data(std::istream &stats_file);
+  bool load_game_stats_from_file(std::string filename);
   void initialiseContinueBoardArray();
   void drawBoard() const;
   void drawScoreBoard(std::ostream &out_stream) const;

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -40,7 +40,7 @@ private:
   bool load_GameBoard_data_from_file(std::string filename);
   bool get_and_process_game_stats_string_data(std::istream &stats_file);
   bool load_game_stats_from_file(std::string filename);
-  void initialiseContinueBoardArray();
+  bool initialiseContinueBoardArray();
   void drawBoard() const;
   void drawScoreBoard(std::ostream &out_stream) const;
   void input(KeyInputErrorStatus err = STATUS_INPUT_VALID);

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -61,6 +61,8 @@ public:
   GameBoard() = default;
   explicit GameBoard(ull playsize)
       : playsize{playsize}, board{std::vector<Tile>(playsize * playsize)} {}
+  explicit GameBoard(ull playsize, const std::vector<Tile> &prempt_board)
+      : playsize{playsize}, board{prempt_board} {}
 
   void setTileValue(point2D_t pt, ull value);
   void setTileBlocked(point2D_t pt, bool blocked);


### PR DESCRIPTION
[This commit can be squashed into one commit if needed] :card_file_box: 

This PR:
* fixes loading saved game data. 
It also makes the loading of data a bit more robust.
* partially makes code to load a `GameBoard{}` more generic.
