### PR TITLE
Save scores & statistics in all board size

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,4 +1,6 @@
 #include "game.hpp"
+#include "menu.hpp"
+
 
 namespace {
 namespace Keypress {
@@ -36,7 +38,7 @@ enum {
 };
 
 enum { CODE_HOTKEY_ACTION_SAVE = 'Z', CODE_HOTKEY_ALTERNATE_ACTION_SAVE = 'P' };
-
+enum {CODE_RETURN_MENU = 'M'};
 } // namespace Code
 } // namespace Keypress
 
@@ -245,17 +247,16 @@ void Game::input(KeyInputErrorStatus err) {
   S or J or ↓ => Down
   D or L or → => Right
   Z or P => Save
+  M => Back to Menu
 
   Press the keys to start and continue.
 
 )";
-
   constexpr auto invalid_prompt_text = "Invalid input. Please try again.";
   constexpr auto sp = "  ";
   std::ostringstream str_os;
   std::ostringstream invalid_prompt_richtext;
   invalid_prompt_richtext << red << sp << invalid_prompt_text << def << "\n\n";
-
   str_os << input_commands_text;
 
   if (err == KeyInputErrorStatus::STATUS_INPUT_ERROR) {
@@ -311,6 +312,10 @@ void Game::input(KeyInputErrorStatus err) {
   case CODE_HOTKEY_ALTERNATE_ACTION_SAVE:
     saveState();
     stateSaved = true;
+    break;
+  case CODE_RETURN_MENU:
+    Menu menu;
+    menu.startMenu();
     break;
   default:
     drawBoard();
@@ -374,7 +379,7 @@ void Game::statistics() const {
 
 void Game::saveStats() const {
   Stats stats;
-  stats.collectStatistics();
+  stats.collectStatistics(gamePlayBoard.getPlaySize());
   stats.bestScore = stats.bestScore < gamePlayBoard.score ?
                         gamePlayBoard.score :
                         stats.bestScore;
@@ -383,7 +388,12 @@ void Game::saveStats() const {
   stats.totalMoveCount += gamePlayBoard.MoveCount();
   stats.totalDuration += duration;
 
-  std::fstream statistics("../data/statistics.txt");
+  std::string file_dir = "../data/statistics" + std::to_string(gamePlayBoard.getPlaySize()) + ".txt";
+  char dir[50];
+  sprintf(dir, "../data/statistics%d.txt", gamePlayBoard.getPlaySize());
+
+  std::remove(dir);
+  std::fstream statistics(file_dir,std::ios_base::app);
   statistics << stats.bestScore << std::endl
              << stats.gameCount << std::endl
              << stats.winCount << std::endl
@@ -395,6 +405,7 @@ void Game::saveStats() const {
 
 void Game::saveScore() const {
   Scoreboard s;
+  s.playsize = gamePlayBoard.getPlaySize();
   s.score = gamePlayBoard.score;
   s.win = gamePlayBoard.hasWon();
   s.moveCount = gamePlayBoard.MoveCount();
@@ -468,13 +479,52 @@ void Game::playGame(ContinueStatus cont) {
   }
   std::cout << str_os.str();
 
-  if (gamePlayBoard.getPlaySize() == COMPETITION_GAME_BOARD_PLAY_SIZE &&
-      cont == ContinueStatus::STATUS_END_GAME) {
+  if(cont == ContinueStatus::STATUS_END_GAME) {
     statistics();
     saveStats();
     newline(2);
     saveScore();
   }
+
+  std::ostringstream str_os1;
+
+  constexpr auto choice_text = "Enter Choice: ";
+  constexpr auto finish_entry_text = R"(
+          1. Play a New Game
+          2. Go back to Menu
+          3. Exit (3 or Else)
+  )";
+
+  bool err = 0;
+
+  std::ostringstream choice_richtext;
+  choice_richtext << "  " << choice_text;
+  str_os1 << "\n";
+  str_os1 << choice_richtext.str();
+  str_os1 << finish_entry_text;
+  std::cout<<str_os1.str();
+  char c;
+  std::cin>>c;
+
+  if(std::cin.eof()){
+    std::cout << std::endl;
+    exit(EXIT_SUCCESS);
+  }
+
+
+
+  switch(c){
+    case '1':
+      startGame();
+      break;
+    case '2':
+      Menu menu;
+      menu.startMenu();
+      break;
+    default:
+      exit(EXIT_SUCCESS);
+  }
+
 }
 
 ull Game::setBoardSize() {
@@ -484,7 +534,7 @@ ull Game::setBoardSize() {
   constexpr auto no_save_found_text =
       "No saved game found. Starting a new game.";
   constexpr auto board_size_prompt_text =
-      "Enter gameboard size (NOTE: Scores and statistics will be saved only for the 4x4 gameboard): ";
+      "Enter gameboard size (3x3 to 10x10). If you want to go back, enter '0': ";
   constexpr auto sp = "  ";
 
   enum { MIN_GAME_BOARD_PLAY_SIZE = 3, MAX_GAME_BOARD_PLAY_SIZE = 10 };
@@ -525,6 +575,10 @@ ull Game::setBoardSize() {
     std::cin.clear();
     std::cin.ignore(std::numeric_limits<std::int32_t>::max(), '\n');
     err = true;
+    if(userInput_PlaySize==0){
+      Menu menu;
+      menu.startMenu();
+    }
   }
   return userInput_PlaySize;
 }
@@ -532,11 +586,11 @@ ull Game::setBoardSize() {
 void Game::startGame() {
 
   Stats stats;
-  if (stats.collectStatistics()) {
-    bestScore = stats.bestScore;
-  }
 
   ull userInput_PlaySize = setBoardSize();
+  if (stats.collectStatistics(userInput_PlaySize)) {
+    bestScore = stats.bestScore;
+  }
 
   gamePlayBoard = GameBoard(userInput_PlaySize);
   gamePlayBoard.addTile();
@@ -547,11 +601,10 @@ void Game::startGame() {
 void Game::continueGame() {
 
   Stats stats;
-  if (stats.collectStatistics()) {
-    bestScore = stats.bestScore;
-  }
-
   if (initialiseContinueBoardArray()) {
+    if (stats.collectStatistics(gamePlayBoard.getPlaySize())) {
+      bestScore = stats.bestScore;
+    }
     playGame(ContinueStatus::STATUS_CONTINUE);
   } else {
     noSave = true;

--- a/src/headers/scores.hpp
+++ b/src/headers/scores.hpp
@@ -25,17 +25,18 @@ private:
   std::vector<Score> scoreList;
   void prompt();
   void writeToFile();
-  void readFile();
+  void readFile(int size);
   void padding(std::string name);
 
 public:
+  ull playsize{0};
   ull score = 0;
   bool win;
   ull largestTile;
   long long moveCount;
   double duration;
-  void printScore();
-  void printStats();
+  void printScore(int boardsize);
+  void printStats(int boardsize);
   void save();
 };
 #endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -7,7 +7,7 @@
 class Stats {
 
 public:
-  bool collectStatistics();
+  bool collectStatistics(int size);
   ull bestScore;
   ull totalMoveCount;
   int gameCount;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -81,10 +81,43 @@ void Menu::continueGame() {
 }
 
 void Menu::showScores() {
+  int boardsize = 0;
 
+  std::ostringstream error_prompt_richtext;
+  std::ostringstream str_os;
+  std::ostringstream board_size_prompt_richtext;
+
+    constexpr auto choose_playsize = "Enter the size of board (3 to 10). If you want to go back, enter '0': ";
+    const auto invalid_prompt_text ={
+      "Invalid input. Gameboard size should range from ", " to ", "."};
+    error_prompt_richtext << red << std::begin(invalid_prompt_text)[0]
+                            << 3
+                            << std::begin(invalid_prompt_text)[1]
+                            << 10
+                            << std::begin(invalid_prompt_text)[2] << def << "\n\n";
+    board_size_prompt_richtext << bold_on << " " << choose_playsize<< bold_off;
+
+
+ bool err = false;
+  while(boardsize < 3 || boardsize > 10){
+    clearScreen();
+    drawAscii();
+    if(err)
+      str_os << error_prompt_richtext.str();
+    str_os << board_size_prompt_richtext.str();
+    std::cout << str_os.str();
+    std::cin >> boardsize;
+    std::cin.clear();
+    std::cin.ignore(std::numeric_limits<std::int32_t>::max(), '\n');
+    err = true;
+    if(boardsize==0){
+      Menu menu;
+      menu.startMenu();
+    }
+  }
   Scoreboard s;
-  s.printScore();
-  s.printStats();
+  s.printScore(boardsize);
+  s.printStats(boardsize);
 }
 
 void drawAscii() {

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -18,15 +18,16 @@ void Scoreboard::prompt() {
 
 void Scoreboard::writeToFile() {
 
-  std::fstream scores("../data/scores.txt", std::ios_base::app);
+  std::string file_dir = "../data/scores"+ std::to_string(playsize) + ".txt";
+  std::fstream scores(file_dir, std::ios_base::app);
   scores << std::endl
-         << name << " " << score << " " << win << " " << moveCount << " "
-         << largestTile << " " << duration;
+  << name << " " << score << " " << win << " " << moveCount << " "
+  << largestTile << " " << duration;
   newline();
   scores.close();
 }
 
-void Scoreboard::printScore() {
+void Scoreboard::printScore(int boardsize) {
   constexpr auto no_save_text = "No saved scores.";
   const auto score_attributes_text = {
       "No.", "Name", "Score", "Won?", "Moves", "Largest Tile", "Duration"};
@@ -43,7 +44,7 @@ void Scoreboard::printScore() {
 
   std::ostringstream str_os;
 
-  readFile();
+  readFile(boardsize);
 
   clearScreen();
   drawAscii();
@@ -77,8 +78,13 @@ void Scoreboard::printScore() {
                     std::to_string(i.score),     i.win ? "Yes" : "No",
                     std::to_string(i.moveCount), std::to_string(i.largestTile),
                     secondsFormat(i.duration)};
+      int hang=0, k;
+      for(k=0;k<data_stats[1].length();k++){
+          if(data_stats[1][k]<0) hang++;
+      }
+      hang = hang/3;
       str_os << sp << "│ " << std::setw(2) << data_stats[0] << ". │ "
-             << std::left << std::setw(18) << data_stats[1] << std::right
+             << std::left <<std::setw(18+hang) << data_stats[1] << std::right
              << " │ " << std::setw(8) << data_stats[2] << " │ " << std::setw(4)
              << data_stats[3] << " │ " << std::setw(5) << data_stats[4] << " │ "
              << std::setw(12) << data_stats[5] << " │ " << std::setw(12)
@@ -96,7 +102,7 @@ void Scoreboard::printScore() {
   std::cout << str_os.str();
 }
 
-void Scoreboard::printStats() {
+void Scoreboard::printStats(int boardsize) {
   constexpr auto stats_title_text = "STATISTICS";
   constexpr auto divider_text = "──────────";
   constexpr auto header_border_text = "┌────────────────────┬─────────────┐";
@@ -110,7 +116,7 @@ void Scoreboard::printStats() {
 
   Stats stats;
   std::ostringstream stats_richtext;
-  if (stats.collectStatistics()) {
+  if (stats.collectStatistics(boardsize)) {
     constexpr auto num_of_stats_attributes_text = 5;
     auto data_stats = std::array<std::string, num_of_stats_attributes_text>{};
     data_stats = {
@@ -160,9 +166,10 @@ void Scoreboard::padding(std::string name) {
   }
 }
 
-void Scoreboard::readFile() {
+void Scoreboard::readFile(int size) {
 
-  std::ifstream scores("../data/scores.txt");
+  std::string file_dir = "../data/scores" + std::to_string(size) + ".txt";
+  std::ifstream scores(file_dir);
   if (scores.fail()) {
     return;
   }

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -1,9 +1,15 @@
 #include "statistics.hpp"
 
-bool Stats::collectStatistics() {
+bool Stats::collectStatistics(int size) {
 
-  std::ifstream statistics("../data/statistics.txt");
+  std::string file_dir = "../data/statistics" + std::to_string(size) + ".txt";
+  std::fstream statistics(file_dir);
   if (statistics.fail()) {
+    bestScore = 0;
+    gameCount = 0;
+    winCount = 0;
+    totalMoveCount = 0;
+    totalDuration = 0;
     return false;
   }
 


### PR DESCRIPTION
save scores of all sizes of game board.
Based on the size of game board, make scores#.txt, statistics#.txt file if there are no saved scores.
if there are saved scores for played board game size, update the file of the size player played.

ex) play 3*3 game first time,
  make scores3.txt & statistics3.txt. Then save scores & statistics.

Thank you :)