### PR TITLE
Enable to go back to menu from statistics and boardsize entering

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -484,7 +484,7 @@ ull Game::setBoardSize() {
   constexpr auto no_save_found_text =
       "No saved game found. Starting a new game.";
   constexpr auto board_size_prompt_text =
-      "Enter gameboard size (NOTE: Scores and statistics will be saved only for the 4x4 gameboard): ";
+      "Enter gameboard size (3x3 to 10x10). If you want to go back, enter '0' (NOTE: Scores and statistics will be saved only for the 4x4 gameboard): ";
   constexpr auto sp = "  ";
 
   enum { MIN_GAME_BOARD_PLAY_SIZE = 3, MAX_GAME_BOARD_PLAY_SIZE = 10 };
@@ -525,6 +525,10 @@ ull Game::setBoardSize() {
     std::cin.clear();
     std::cin.ignore(std::numeric_limits<std::int32_t>::max(), '\n');
     err = true;
+	if(userInput_PlaySize == 0){
+		Menu menu;
+		menu.startMenu();
+	}
   }
   return userInput_PlaySize;
 }

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -105,7 +105,7 @@ void Scoreboard::printStats() {
                                       "Number of Wins", "Total Moves Played",
                                       "Total Duration"};
   constexpr auto no_save_text = "No saved statistics.";
-  constexpr auto any_key_exit_text = "Press any key to exit: ";
+  constexpr auto any_key_exit_text = "Press any key to exit. If you want to go back to menu, press 'm': ";
   constexpr auto sp = "  ";
 
   Stats stats;
@@ -149,6 +149,10 @@ void Scoreboard::printStats() {
   std::cout << stats_richtext.str();
   char c;
   std::cin >> c;
+  if(c == 'm'){
+	  Menu menu;
+	  menu.startMenu();
+  }
   exit(EXIT_SUCCESS);
 }
 


### PR DESCRIPTION
After checking statistics or boardsize entering before game start, there is not any way to go back to menu. There is just exiting or starting games ahead.

Thank you for reading!