### PR TITLE
Fix: Refactored Inputs and some UI from Game Logic

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -287,16 +287,16 @@ void Game::input() {
         getInput(c);
         switch (c) {
         case CODE_ANSI_UP:
-          decideMove(UP);
+          intendedmove[FLAG_MOVE_UP] = true;
           return;
         case CODE_ANSI_DOWN:
-          decideMove(DOWN);
+          intendedmove[FLAG_MOVE_DOWN] = true;
           return;
         case CODE_ANSI_RIGHT:
-          decideMove(RIGHT);
+          intendedmove[FLAG_MOVE_RIGHT] = true;
           return;
         case CODE_ANSI_LEFT:
-          decideMove(LEFT);
+          intendedmove[FLAG_MOVE_LEFT] = true;
           return;
         }
       }
@@ -306,19 +306,19 @@ void Game::input() {
 
     case CODE_WASD_UP:
     case CODE_VIM_UP:
-      decideMove(UP);
+      intendedmove[FLAG_MOVE_UP] = true;
       break;
     case CODE_WASD_LEFT:
     case CODE_VIM_LEFT:
-      decideMove(LEFT);
+      intendedmove[FLAG_MOVE_LEFT] = true;
       break;
     case CODE_WASD_DOWN:
     case CODE_VIM_DOWN:
-      decideMove(DOWN);
+      intendedmove[FLAG_MOVE_DOWN] = true;
       break;
     case CODE_WASD_RIGHT:
     case CODE_VIM_RIGHT:
-      decideMove(RIGHT);
+      intendedmove[FLAG_MOVE_RIGHT] = true;
       break;
     case CODE_HOTKEY_ACTION_SAVE:
     case CODE_HOTKEY_ALTERNATE_ACTION_SAVE:
@@ -486,6 +486,24 @@ void Game::process_gamelogic() {
   }
 }
 
+bool Game::process_intendedMove() {
+  if (intendedmove[FLAG_MOVE_LEFT]) {
+    decideMove(LEFT);
+  }
+  if (intendedmove[FLAG_MOVE_RIGHT]) {
+    decideMove(RIGHT);
+  }
+  if (intendedmove[FLAG_MOVE_UP]) {
+    decideMove(UP);
+  }
+  if (intendedmove[FLAG_MOVE_DOWN]) {
+    decideMove(DOWN);
+  }
+  // Reset all move flags...
+  intendedmove = intendedmove_t{};
+  return true;
+}
+
 bool Game::process_gameStatus() {
   if (gamestatus[FLAG_WIN]) {
     // break if question asked
@@ -505,6 +523,7 @@ bool Game::soloGameLoop() {
   process_gamelogic();
   drawGraphics();
   input();
+  process_intendedMove();
   const auto loop_again = process_gameStatus();
   return loop_again;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -425,6 +425,28 @@ void Game::saveState() const {
   stats.close();
 }
 
+void Game::drawEndScreen() {
+  constexpr auto win_game_text = "You win! Congratulations!";
+  constexpr auto lose_game_text = "Game over! You lose.";
+  constexpr auto sp = "  ";
+
+  std::ostringstream str_os;
+  std::ostringstream win_richtext;
+  win_richtext << green << bold_on << sp << win_game_text << def << bold_off
+               << "\n\n\n";
+
+  std::ostringstream lose_richtext;
+  lose_richtext << red << bold_on << sp << lose_game_text << def << bold_off
+                << "\n\n\n";
+
+  if (gamePlayBoard.hasWon()) {
+    str_os << win_richtext.str();
+  } else {
+    str_os << lose_richtext.str();
+  }
+  std::cout << str_os.str();
+}
+
 void Game::drawGameState() {
   constexpr auto state_saved_text =
       "The game has been saved. Feel free to take a break.";
@@ -487,19 +509,6 @@ void Game::endlessGameLoop() {
 }
 
 void Game::playGame(ContinueStatus cont) {
-  constexpr auto win_game_text = "You win! Congratulations!";
-  constexpr auto lose_game_text = "Game over! You lose.";
-  constexpr auto sp = "  ";
-
-  std::ostringstream str_os;
-  std::ostringstream win_richtext;
-  win_richtext << green << bold_on << sp << win_game_text << def << bold_off
-               << "\n\n\n";
-
-  std::ostringstream lose_richtext;
-  lose_richtext << red << bold_on << sp << lose_game_text << def << bold_off
-                << "\n\n\n";
-
   auto startTime = std::chrono::high_resolution_clock::now();
   endlessGameLoop();
   auto finishTime = std::chrono::high_resolution_clock::now();
@@ -507,13 +516,7 @@ void Game::playGame(ContinueStatus cont) {
   duration = elapsed.count();
 
   drawBoard();
-
-  if (gamePlayBoard.hasWon()) {
-    str_os << win_richtext.str();
-  } else {
-    str_os << lose_richtext.str();
-  }
-  std::cout << str_os.str();
+  drawEndScreen();
 
   if (gamePlayBoard.getPlaySize() == COMPETITION_GAME_BOARD_PLAY_SIZE &&
       cont == ContinueStatus::STATUS_END_GAME) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -484,9 +484,7 @@ void Game::process_gamelogic() {
   }
 }
 
-bool Game::soloGameLoop() {
-  process_gamelogic();
-
+bool Game::process_gameStatus() {
   if (gamestatus[FLAG_WIN]) {
     // break if question asked
     return false;
@@ -498,10 +496,19 @@ bool Game::soloGameLoop() {
   if (gamestatus[FLAG_SAVED_GAME]) {
     saveState();
   }
+  return true;
+}
+
+bool Game::soloGameLoop() {
+  process_gamelogic();
 
   drawGraphics();
-  input();
-  return true;
+  if (!gamestatus[FLAG_END_GAME]) {
+    // Fast track: Game has ended, no input can be done.
+    input();
+  }
+  const auto loop_again = process_gameStatus();
+  return loop_again;
 }
 
 void Game::endlessGameLoop() {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -262,19 +262,21 @@ void Game::drawInputError() {
 }
 
 void Game::drawInputControls() {
-  constexpr auto input_commands_text = u8R"(
-  W or K or ↑ => Up
-  A or H or ← => Left
-  S or J or ↓ => Down
-  D or L or → => Right
-  Z or P => Save
-
-  Press the keys to start and continue.
-
-)";
+  constexpr auto sp = "  ";
+  const auto input_commands_list_text = {
+      "W or K or ↑ => Up",
+      "A or H or ← => Left",
+      "S or J or ↓ => Down",
+      "D or L or → => Right",
+      "Z or P => Save",
+      "",
+      "Press the keys to start and continue.",
+      "\n"};
 
   std::ostringstream str_os;
-  str_os << input_commands_text;
+  for (const auto txt : input_commands_list_text) {
+    str_os << sp << txt << "\n";
+  }
   std::cout << str_os.str();
 }
 
@@ -600,7 +602,6 @@ ull Game::setBoardSize() {
 
   enum { MIN_GAME_BOARD_PLAY_SIZE = 3, MAX_GAME_BOARD_PLAY_SIZE = 10 };
 
-  std::ostringstream str_os;
   std::ostringstream error_prompt_richtext;
   error_prompt_richtext << red << sp << std::begin(invalid_prompt_text)[0]
                         << MIN_GAME_BOARD_PLAY_SIZE
@@ -619,6 +620,7 @@ ull Game::setBoardSize() {
 
   while ((userInput_PlaySize < MIN_GAME_BOARD_PLAY_SIZE ||
           userInput_PlaySize > MAX_GAME_BOARD_PLAY_SIZE)) {
+    std::ostringstream str_os;
     clearScreen();
     drawAscii();
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -275,57 +275,59 @@ void Game::drawInputControls() {
 }
 
 void Game::input() {
-
   using namespace Keypress::Code;
-  char c;
-  getInput(c);
-
-  if (c == CODE_ANSI_TRIGGER_1) {
+  if (!gamestatus[FLAG_END_GAME]) {
+    // Game still in play. Take input commands for next turn.
+    char c;
     getInput(c);
-    if (c == CODE_ANSI_TRIGGER_2) {
+
+    if (c == CODE_ANSI_TRIGGER_1) {
       getInput(c);
-      switch (c) {
-      case CODE_ANSI_UP:
-        decideMove(UP);
-        return;
-      case CODE_ANSI_DOWN:
-        decideMove(DOWN);
-        return;
-      case CODE_ANSI_RIGHT:
-        decideMove(RIGHT);
-        return;
-      case CODE_ANSI_LEFT:
-        decideMove(LEFT);
-        return;
+      if (c == CODE_ANSI_TRIGGER_2) {
+        getInput(c);
+        switch (c) {
+        case CODE_ANSI_UP:
+          decideMove(UP);
+          return;
+        case CODE_ANSI_DOWN:
+          decideMove(DOWN);
+          return;
+        case CODE_ANSI_RIGHT:
+          decideMove(RIGHT);
+          return;
+        case CODE_ANSI_LEFT:
+          decideMove(LEFT);
+          return;
+        }
       }
     }
-  }
 
-  switch (toupper(c)) {
+    switch (toupper(c)) {
 
-  case CODE_WASD_UP:
-  case CODE_VIM_UP:
-    decideMove(UP);
-    break;
-  case CODE_WASD_LEFT:
-  case CODE_VIM_LEFT:
-    decideMove(LEFT);
-    break;
-  case CODE_WASD_DOWN:
-  case CODE_VIM_DOWN:
-    decideMove(DOWN);
-    break;
-  case CODE_WASD_RIGHT:
-  case CODE_VIM_RIGHT:
-    decideMove(RIGHT);
-    break;
-  case CODE_HOTKEY_ACTION_SAVE:
-  case CODE_HOTKEY_ALTERNATE_ACTION_SAVE:
-    gamestatus[FLAG_SAVED_GAME] = true;
-    break;
-  default:
-    input_err = KeyInputErrorStatus::STATUS_INPUT_ERROR;
-    break;
+    case CODE_WASD_UP:
+    case CODE_VIM_UP:
+      decideMove(UP);
+      break;
+    case CODE_WASD_LEFT:
+    case CODE_VIM_LEFT:
+      decideMove(LEFT);
+      break;
+    case CODE_WASD_DOWN:
+    case CODE_VIM_DOWN:
+      decideMove(DOWN);
+      break;
+    case CODE_WASD_RIGHT:
+    case CODE_VIM_RIGHT:
+      decideMove(RIGHT);
+      break;
+    case CODE_HOTKEY_ACTION_SAVE:
+    case CODE_HOTKEY_ALTERNATE_ACTION_SAVE:
+      gamestatus[FLAG_SAVED_GAME] = true;
+      break;
+    default:
+      input_err = KeyInputErrorStatus::STATUS_INPUT_ERROR;
+      break;
+    }
   }
 }
 
@@ -501,12 +503,8 @@ bool Game::process_gameStatus() {
 
 bool Game::soloGameLoop() {
   process_gamelogic();
-
   drawGraphics();
-  if (!gamestatus[FLAG_END_GAME]) {
-    // Fast track: Game has ended, no input can be done.
-    input();
-  }
+  input();
   const auto loop_again = process_gameStatus();
   return loop_again;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -247,6 +247,20 @@ void Game::drawScoreBoard(std::ostream &out_stream) const {
   out_stream << outer_border_padding << bottom_board << "\n \n";
 }
 
+void Game::drawInputError() {
+  constexpr auto invalid_prompt_text = "Invalid input. Please try again.";
+  constexpr auto sp = "  ";
+  std::ostringstream str_os;
+  std::ostringstream invalid_prompt_richtext;
+  invalid_prompt_richtext << red << sp << invalid_prompt_text << def << "\n\n";
+
+  if (gamestatus[FLAG_INPUT_ERROR]) {
+    str_os << invalid_prompt_richtext.str();
+    gamestatus[FLAG_INPUT_ERROR] = false;
+  }
+  std::cout << str_os.str();
+}
+
 void Game::drawInputControls() {
   constexpr auto input_commands_text = u8R"(
   W or K or ↑ => Up
@@ -259,18 +273,8 @@ void Game::drawInputControls() {
 
 )";
 
-  constexpr auto invalid_prompt_text = "Invalid input. Please try again.";
-  constexpr auto sp = "  ";
   std::ostringstream str_os;
-  std::ostringstream invalid_prompt_richtext;
-  invalid_prompt_richtext << red << sp << invalid_prompt_text << def << "\n\n";
-
   str_os << input_commands_text;
-
-  if (gamestatus[FLAG_INPUT_ERROR]) {
-    str_os << invalid_prompt_richtext.str();
-    gamestatus[FLAG_INPUT_ERROR] = false;
-  }
   std::cout << str_os.str();
 }
 
@@ -500,6 +504,7 @@ void Game::drawGraphics() {
   drawBoard();
   drawGameState();
   drawInputControls();
+  drawInputError();
 }
 
 void Game::process_gamelogic() {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -274,59 +274,90 @@ void Game::drawInputControls() {
   std::cout << str_os.str();
 }
 
-void Game::input() {
+bool Game::check_input_ansi(char c) {
   using namespace Keypress::Code;
-  if (!gamestatus[FLAG_END_GAME]) {
+  if (c == CODE_ANSI_TRIGGER_1) {
+    getInput(c);
+    if (c == CODE_ANSI_TRIGGER_2) {
+      getInput(c);
+      switch (c) {
+      case CODE_ANSI_UP:
+        intendedmove[FLAG_MOVE_UP] = true;
+        return false;
+      case CODE_ANSI_DOWN:
+        intendedmove[FLAG_MOVE_DOWN] = true;
+        return false;
+      case CODE_ANSI_RIGHT:
+        intendedmove[FLAG_MOVE_RIGHT] = true;
+        return false;
+      case CODE_ANSI_LEFT:
+        intendedmove[FLAG_MOVE_LEFT] = true;
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool Game::check_input_vim(char c) {
+  using namespace Keypress::Code;
+  switch (toupper(c)) {
+  case CODE_VIM_UP:
+    intendedmove[FLAG_MOVE_UP] = true;
+    return false;
+  case CODE_VIM_LEFT:
+    intendedmove[FLAG_MOVE_LEFT] = true;
+    return false;
+  case CODE_VIM_DOWN:
+    intendedmove[FLAG_MOVE_DOWN] = true;
+    return false;
+  case CODE_VIM_RIGHT:
+    intendedmove[FLAG_MOVE_RIGHT] = true;
+    return false;
+  }
+  return true;
+}
+
+bool Game::check_input_wasd(char c) {
+  using namespace Keypress::Code;
+  switch (toupper(c)) {
+  case CODE_WASD_UP:
+    intendedmove[FLAG_MOVE_UP] = true;
+    return false;
+  case CODE_WASD_LEFT:
+    intendedmove[FLAG_MOVE_LEFT] = true;
+    return false;
+  case CODE_WASD_DOWN:
+    intendedmove[FLAG_MOVE_DOWN] = true;
+    return false;
+  case CODE_WASD_RIGHT:
+    intendedmove[FLAG_MOVE_RIGHT] = true;
+    return false;
+  }
+  return true;
+}
+
+bool Game::check_input_other(char c) {
+  using namespace Keypress::Code;
+  switch (toupper(c)) {
+  case CODE_HOTKEY_ACTION_SAVE:
+  case CODE_HOTKEY_ALTERNATE_ACTION_SAVE:
+    gamestatus[FLAG_SAVED_GAME] = true;
+    return false;
+  }
+  return true;
+}
+
+void Game::input() {
+  if (!gamestatus[FLAG_END_GAME] && !gamestatus[FLAG_WIN]) {
     // Game still in play. Take input commands for next turn.
     char c;
     getInput(c);
-
-    if (c == CODE_ANSI_TRIGGER_1) {
-      getInput(c);
-      if (c == CODE_ANSI_TRIGGER_2) {
-        getInput(c);
-        switch (c) {
-        case CODE_ANSI_UP:
-          intendedmove[FLAG_MOVE_UP] = true;
-          return;
-        case CODE_ANSI_DOWN:
-          intendedmove[FLAG_MOVE_DOWN] = true;
-          return;
-        case CODE_ANSI_RIGHT:
-          intendedmove[FLAG_MOVE_RIGHT] = true;
-          return;
-        case CODE_ANSI_LEFT:
-          intendedmove[FLAG_MOVE_LEFT] = true;
-          return;
-        }
-      }
-    }
-
-    switch (toupper(c)) {
-
-    case CODE_WASD_UP:
-    case CODE_VIM_UP:
-      intendedmove[FLAG_MOVE_UP] = true;
-      break;
-    case CODE_WASD_LEFT:
-    case CODE_VIM_LEFT:
-      intendedmove[FLAG_MOVE_LEFT] = true;
-      break;
-    case CODE_WASD_DOWN:
-    case CODE_VIM_DOWN:
-      intendedmove[FLAG_MOVE_DOWN] = true;
-      break;
-    case CODE_WASD_RIGHT:
-    case CODE_VIM_RIGHT:
-      intendedmove[FLAG_MOVE_RIGHT] = true;
-      break;
-    case CODE_HOTKEY_ACTION_SAVE:
-    case CODE_HOTKEY_ALTERNATE_ACTION_SAVE:
-      gamestatus[FLAG_SAVED_GAME] = true;
-      break;
-    default:
+    const auto is_invalid_keypress_code =
+        check_input_ansi(c) && check_input_wasd(c) && check_input_vim(c) &&
+        check_input_other(c);
+    if (is_invalid_keypress_code) {
       gamestatus[FLAG_INPUT_ERROR] = true;
-      break;
     }
   }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -485,8 +485,7 @@ std::tuple<bool, bool> Game::process_gamelogic() {
 }
 
 bool Game::soloGameLoop() {
-  enum GameStatusFlag { FLAG_WIN, FLAG_END_GAME, MAX_NO_GAME_STATUS_FLAGS };
-  auto gamestatus = std::array<bool, MAX_NO_GAME_STATUS_FLAGS>{};
+  auto gamestatus = gamestatus_t{};
   const auto logic_results = process_gamelogic();
   std::tie(gamestatus[FLAG_WIN], gamestatus[FLAG_END_GAME]) = logic_results;
   if (gamestatus[FLAG_WIN]) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -321,7 +321,6 @@ void Game::input() {
     break;
   case CODE_HOTKEY_ACTION_SAVE:
   case CODE_HOTKEY_ALTERNATE_ACTION_SAVE:
-    saveState();
     stateSaved = true;
     break;
   default:
@@ -497,6 +496,9 @@ bool Game::soloGameLoop() {
   if (gamestatus[FLAG_END_GAME]) {
     // End endless_mode;
     return false;
+  }
+  if (stateSaved) {
+    saveState();
   }
   drawGraphics();
   input();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -463,24 +463,27 @@ std::tuple<bool, bool> Game::process_gamelogic() {
   return std::make_tuple(false, false);
 }
 
-void Game::gameloop() {
+bool Game::soloGameLoop() {
   enum GameStatusFlag { FLAG_WIN, FLAG_END_GAME, MAX_NO_GAME_STATUS_FLAGS };
   auto gamestatus = std::array<bool, MAX_NO_GAME_STATUS_FLAGS>{};
-
-  bool endless_mode = true;
-  while (endless_mode) {
-    const auto logic_results = process_gamelogic();
-    std::tie(gamestatus[FLAG_WIN], gamestatus[FLAG_END_GAME]) = logic_results;
-    if (gamestatus[FLAG_WIN]) {
-      // break if question asked
-    }
-    if (gamestatus[FLAG_END_GAME]) {
-      // End endless_mode;
-      break;
-    }
-    drawGraphics();
-    input();
+  const auto logic_results = process_gamelogic();
+  std::tie(gamestatus[FLAG_WIN], gamestatus[FLAG_END_GAME]) = logic_results;
+  if (gamestatus[FLAG_WIN]) {
+    // break if question asked
+    return false;
   }
+  if (gamestatus[FLAG_END_GAME]) {
+    // End endless_mode;
+    return false;
+  }
+  drawGraphics();
+  input();
+  return true;
+}
+
+void Game::endlessGameLoop() {
+  while (soloGameLoop())
+    ;
 }
 
 void Game::playGame(ContinueStatus cont) {
@@ -498,7 +501,7 @@ void Game::playGame(ContinueStatus cont) {
                 << "\n\n\n";
 
   auto startTime = std::chrono::high_resolution_clock::now();
-  gameloop();
+  endlessGameLoop();
   auto finishTime = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = finishTime - startTime;
   duration = elapsed.count();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -267,9 +267,9 @@ void Game::drawInputControls() {
 
   str_os << input_commands_text;
 
-  if (input_err == KeyInputErrorStatus::STATUS_INPUT_ERROR) {
+  if (gamestatus[FLAG_INPUT_ERROR]) {
     str_os << invalid_prompt_richtext.str();
-    input_err = KeyInputErrorStatus::STATUS_INPUT_VALID;
+    gamestatus[FLAG_INPUT_ERROR] = false;
   }
   std::cout << str_os.str();
 }
@@ -325,7 +325,7 @@ void Game::input() {
       gamestatus[FLAG_SAVED_GAME] = true;
       break;
     default:
-      input_err = KeyInputErrorStatus::STATUS_INPUT_ERROR;
+      gamestatus[FLAG_INPUT_ERROR] = true;
       break;
     }
   }

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -10,10 +10,15 @@ enum Directions { UP, DOWN, RIGHT, LEFT };
 class Game {
 private:
   enum ContinueStatus { STATUS_END_GAME = 0, STATUS_CONTINUE = 1 };
-  enum KeyInputErrorStatus { STATUS_INPUT_VALID = 0, STATUS_INPUT_ERROR = 1 };
   enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
 
-  enum GameStatusFlag { FLAG_WIN, FLAG_END_GAME, FLAG_SAVED_GAME, MAX_NO_GAME_STATUS_FLAGS };
+  enum GameStatusFlag {
+    FLAG_WIN,
+    FLAG_END_GAME,
+    FLAG_SAVED_GAME,
+    FLAG_INPUT_ERROR,
+    MAX_NO_GAME_STATUS_FLAGS
+  };
 
   using gamestatus_t = std::array<bool, MAX_NO_GAME_STATUS_FLAGS>;
 
@@ -24,7 +29,6 @@ private:
   GameBoard gamePlayBoard;
   RandInt randInt;
   bool noSave;
-  KeyInputErrorStatus input_err{STATUS_INPUT_VALID};
 
   bool get_and_process_game_stats_string_data(std::istream &stats_file);
   bool load_game_stats_from_file(std::string filename);

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -74,6 +74,7 @@ private:
   void process_gamelogic();
   bool process_intendedMove();
   bool process_gameStatus();
+  void drawInputError();
   void drawInputControls();
 
 public:

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -3,6 +3,7 @@
 
 #include "gameboard.hpp"
 #include "global.hpp"
+#include <array>
 
 enum Directions { UP, DOWN, RIGHT, LEFT };
 
@@ -11,6 +12,10 @@ private:
   enum ContinueStatus { STATUS_END_GAME = 0, STATUS_CONTINUE = 1 };
   enum KeyInputErrorStatus { STATUS_INPUT_VALID = 0, STATUS_INPUT_ERROR = 1 };
   enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
+
+  enum GameStatusFlag { FLAG_WIN, FLAG_END_GAME, MAX_NO_GAME_STATUS_FLAGS };
+
+  using gamestatus_t = std::array<bool, MAX_NO_GAME_STATUS_FLAGS>;
 
   ull bestScore;
   double duration;

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -13,15 +13,16 @@ private:
   enum KeyInputErrorStatus { STATUS_INPUT_VALID = 0, STATUS_INPUT_ERROR = 1 };
   enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
 
-  enum GameStatusFlag { FLAG_WIN, FLAG_END_GAME, MAX_NO_GAME_STATUS_FLAGS };
+  enum GameStatusFlag { FLAG_WIN, FLAG_END_GAME, FLAG_SAVED_GAME, MAX_NO_GAME_STATUS_FLAGS };
 
   using gamestatus_t = std::array<bool, MAX_NO_GAME_STATUS_FLAGS>;
+
+  gamestatus_t gamestatus{};
 
   ull bestScore;
   double duration;
   GameBoard gamePlayBoard;
   RandInt randInt;
-  bool stateSaved;
   bool noSave;
   KeyInputErrorStatus input_err{STATUS_INPUT_VALID};
 
@@ -51,11 +52,11 @@ private:
 
   void drawGraphics();
   void endlessGameLoop();
-  std::tuple<bool, bool> process_gamelogic();
+  void process_gamelogic();
   void drawInputControls();
 
 public:
-  Game() : bestScore(0), duration(0.0), stateSaved(false), noSave(false) {}
+  Game() : bestScore(0), duration(0.0), noSave(false) {}
   void startGame();
   void continueGame();
 };

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -49,6 +49,10 @@ private:
   void drawBoard() const;
   void drawGameState();
   void drawScoreBoard(std::ostream &out_stream) const;
+  bool check_input_ansi(char c);
+  bool check_input_wasd(char c);
+  bool check_input_vim(char c);
+  bool check_input_other(char c);
   void input();
   void decideMove(Directions);
 

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -8,23 +8,25 @@ enum Directions { UP, DOWN, RIGHT, LEFT };
 
 class Game {
 private:
+  enum ContinueStatus { STATUS_END_GAME = 0, STATUS_CONTINUE = 1 };
+  enum KeyInputErrorStatus { STATUS_INPUT_VALID = 0, STATUS_INPUT_ERROR = 1 };
+  enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
+
   ull bestScore;
   double duration;
   GameBoard gamePlayBoard;
   RandInt randInt;
   bool stateSaved;
   bool noSave;
-
-  enum ContinueStatus { STATUS_END_GAME = 0, STATUS_CONTINUE = 1 };
-  enum KeyInputErrorStatus { STATUS_INPUT_VALID = 0, STATUS_INPUT_ERROR = 1 };
-  enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
+  KeyInputErrorStatus input_err{STATUS_INPUT_VALID};
 
   bool get_and_process_game_stats_string_data(std::istream &stats_file);
   bool load_game_stats_from_file(std::string filename);
   bool initialiseContinueBoardArray();
   void drawBoard() const;
+  void drawGameState();
   void drawScoreBoard(std::ostream &out_stream) const;
-  void input(KeyInputErrorStatus err = STATUS_INPUT_VALID);
+  void input();
   void decideMove(Directions);
 
   bool collaspeTiles(point2D_t pt, point2D_t pt_offset);
@@ -39,6 +41,11 @@ private:
   void saveState() const;
   void playGame(ContinueStatus);
   ull setBoardSize();
+
+  void drawGraphics();
+  void gameloop();
+  std::tuple<bool, bool> process_gamelogic();
+  void drawInputControls();
 
 public:
   Game() : bestScore(0), duration(0.0), stateSaved(false), noSave(false) {}

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -24,6 +24,7 @@ private:
   bool load_game_stats_from_file(std::string filename);
   bool initialiseContinueBoardArray();
   bool soloGameLoop();
+  void drawEndScreen();
   void drawBoard() const;
   void drawGameState();
   void drawScoreBoard(std::ostream &out_stream) const;

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -23,6 +23,7 @@ private:
   bool get_and_process_game_stats_string_data(std::istream &stats_file);
   bool load_game_stats_from_file(std::string filename);
   bool initialiseContinueBoardArray();
+  bool soloGameLoop();
   void drawBoard() const;
   void drawGameState();
   void drawScoreBoard(std::ostream &out_stream) const;
@@ -43,7 +44,7 @@ private:
   ull setBoardSize();
 
   void drawGraphics();
-  void gameloop();
+  void endlessGameLoop();
   std::tuple<bool, bool> process_gamelogic();
   void drawInputControls();
 

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -53,6 +53,7 @@ private:
   void drawGraphics();
   void endlessGameLoop();
   void process_gamelogic();
+  bool process_gameStatus();
   void drawInputControls();
 
 public:

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -24,6 +24,17 @@ private:
 
   gamestatus_t gamestatus{};
 
+  enum IntendedMoveFlag {
+    FLAG_MOVE_LEFT,
+    FLAG_MOVE_RIGHT,
+    FLAG_MOVE_UP,
+    FLAG_MOVE_DOWN,
+    MAX_NO_INTENDED_MOVE_FLAGS
+  };
+
+  using intendedmove_t = std::array<bool, MAX_NO_INTENDED_MOVE_FLAGS>;
+  intendedmove_t intendedmove{};
+
   ull bestScore;
   double duration;
   GameBoard gamePlayBoard;
@@ -57,6 +68,7 @@ private:
   void drawGraphics();
   void endlessGameLoop();
   void process_gamelogic();
+  bool process_intendedMove();
   bool process_gameStatus();
   void drawInputControls();
 


### PR DESCRIPTION
* _"Input"_ (Keypress) logic and _"Game Action"_ logic have been separated quite a bit.
  This helps breaks up the main _input_ function into smaller ones based on a _"keypress"_ style.
  * _Keypress styles_ now have their own functions.
    * This makes it easier to test if keypresses are working.
    * Keypresses now _"flag an intent"_ for the game _"to do X action"_.

* _"Flag"_-based processing introduced in the game.
  In this PR...
  * `GameStatusFlag` for all game-related statuses like _win_ / _lose_ / _save_ (and returning soon _endless-mode_)...
  * `IntendedMoveFlag` for all move-related statuses like "tumbleLeft" or "tumbleRight".
    * This will help in creating _"replayable"-based tests_.
    * Will be encapsulated / separated further in a future PR.
  * Depending on which flags enabled / disabled, game-logic does action (which is) flagged accordingly.
* "Printing" of UI text is encouraged to be in its own specialised function.

Will clean up code in further PRs.