### PR TITLE
Fix compilation warning

### DIFF
--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -24,8 +24,8 @@ private:
 };
 
 class GameBoard {
-  std::vector<Tile> board;
   ull playsize{0};
+  std::vector<Tile> board;
   bool win{};
 
   Tile getTile(point2D_t pt) const;


### PR DESCRIPTION
I'm using GCC 8.2.1 and I got [-Wreorder] warning during compilation.

/home/tomasz/code/2048.cpp/src/headers/gameboard.hpp: In constructor ‘GameBoard::GameBoard(ull)’:                                                                         
/home/tomasz/code/2048.cpp/src/headers/gameboard.hpp:28:17: warning: ‘GameBoard::playsize’ will be initialized after [-Wreorder]                                          
   ull playsize{0};                                                                                                                                                       
                 ^                                                                                                                                                        
/home/tomasz/code/2048.cpp/src/headers/gameboard.hpp:27:21: warning:   ‘std::vector<Tile> GameBoard::board’ [-Wreorder]                                                   
   std::vector<Tile> board;                                                                                                                                               
                     ^~~~~                                                                                                                                                
/home/tomasz/code/2048.cpp/src/headers/gameboard.hpp:57:12: warning:   when initialized here [-Wreorder]                                                                  
   explicit GameBoard(ull playsize)                                                                                                                                       
            ^~~~~~~~~   