### PR TITLE
Fix: Convert Menu class to a namespaced area

### DIFF
--- a/src/2048.cpp
+++ b/src/2048.cpp
@@ -4,8 +4,7 @@
 
 int main() {
 
-  Menu menu;
-  menu.startMenu();
+  Menu::startMenu();
 
   return EXIT_SUCCESS;
 }

--- a/src/2048.cpp
+++ b/src/2048.cpp
@@ -1,10 +1,7 @@
 #include "2048.hpp"
-#include "global.hpp"
 #include "menu.hpp"
 
 int main() {
-
   Menu::startMenu();
-
-  return EXIT_SUCCESS;
+  return 0;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -532,7 +532,8 @@ void Game::drawGameState() {
 }
 
 void Game::drawEndOfGamePrompt() {
-  constexpr auto win_but_what_next = "You Won! Continue playing current game? [y/n]";
+  constexpr auto win_but_what_next =
+      "You Won! Continue playing current game? [y/n]";
   constexpr auto sp = "  ";
 
   std::ostringstream str_os;

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -1,4 +1,5 @@
 #include "global.hpp"
+#include "color.hpp"
 #include <iostream>
 #include <sstream>
 
@@ -47,6 +48,24 @@ void newline(int n) {
 void clearScreen() {
   system("clear");
 };
+
+void drawAscii() {
+  constexpr auto title_card_2048 = R"(
+   /\\\\\\\\\          /\\\\\\\                /\\\         /\\\\\\\\\
+  /\\\///////\\\      /\\\/////\\\            /\\\\\       /\\\///////\\\
+  \///      \//\\\    /\\\    \//\\\         /\\\/\\\      \/\\\     \/\\\
+             /\\\/    \/\\\     \/\\\       /\\\/\/\\\      \///\\\\\\\\\/
+           /\\\//      \/\\\     \/\\\     /\\\/  \/\\\       /\\\///////\\\
+         /\\\//         \/\\\     \/\\\   /\\\\\\\\\\\\\\\\   /\\\      \//\\\
+        /\\\/            \//\\\    /\\\   \///////////\\\//   \//\\\      /\\\
+        /\\\\\\\\\\\\\\\   \///\\\\\\\/              \/\\\      \///\\\\\\\\\/
+        \///////////////      \///////                \///         \/////////
+  )";
+  std::ostringstream title_card_richtext;
+  title_card_richtext << green << bold_on << title_card_2048 << bold_off << def;
+  title_card_richtext << "\n\n\n";
+  std::cout << title_card_richtext.str();
+}
 
 std::string secondsFormat(double sec) {
   double s = sec;

--- a/src/headers/global.hpp
+++ b/src/headers/global.hpp
@@ -7,6 +7,7 @@ using ull = unsigned long long;
 void getInput(char &);
 void newline(int n = 1);
 void clearScreen();
+void drawAscii();
 std::string secondsFormat(double);
 
 #endif

--- a/src/headers/menu.hpp
+++ b/src/headers/menu.hpp
@@ -1,18 +1,8 @@
 #ifndef MENU_H
 #define MENU_H
 
-class Menu {
-private:
-  void startGame();
-  void showScores();
-  void printMenu();
-  void input(int err);
-  void continueGame();
-
-public:
-  void startMenu(int err = 0);
-};
-
-void drawAscii();
+namespace Menu {
+void startMenu(int err = 0);
+} // namespace Menu
 
 #endif

--- a/src/headers/menu.hpp
+++ b/src/headers/menu.hpp
@@ -2,7 +2,7 @@
 #define MENU_H
 
 namespace Menu {
-void startMenu(int err = 0);
+void startMenu();
 } // namespace Menu
 
 #endif

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -39,7 +39,7 @@ void showScores() {
   s.printStats();
 }
 
-void drawMainMenuTitle() {
+void drawMainMenuTitle(std::ostream &out_os) {
   constexpr auto greetings_text = "Welcome to ";
   constexpr auto gamename_text = "2048!";
   constexpr auto sp = "  ";
@@ -50,10 +50,10 @@ void drawMainMenuTitle() {
                  << def << bold_off << "\n";
 
   str_os << title_richtext.str();
-  std::cout << str_os.str();
+  out_os << str_os.str();
 }
 
-void drawMainMenuOptions() {
+void drawMainMenuOptions(std::ostream &out_os) {
   const auto menu_list_txt = {"1. Play a New Game", "2. Continue Previous Game",
                               "3. View Highscores and Statistics", "4. Exit"};
   constexpr auto sp = "        ";
@@ -66,10 +66,10 @@ void drawMainMenuOptions() {
   }
   str_os << "\n";
 
-  std::cout << str_os.str();
+  out_os << str_os.str();
 }
 
-void drawInputMenuPrompt(bool err) {
+void drawInputMenuPrompt(std::ostream &out_os, bool err) {
   constexpr auto err_input_text = "Invalid input. Please try again.";
   constexpr auto prompt_choice_text = "Enter Choice: ";
   constexpr auto sp = "  ";
@@ -86,14 +86,14 @@ void drawInputMenuPrompt(bool err) {
   }
   str_os << prompt_choice_richtext.str();
 
-  std::cout << str_os.str();
+  out_os << str_os.str();
 }
 
-void drawMainMenuGraphics() {
+void drawMainMenuGraphics(std::ostream &out_os) {
   drawAscii();
-  drawMainMenuTitle();
-  drawMainMenuOptions();
-  drawInputMenuPrompt(FlagInputErrornousChoice);
+  drawMainMenuTitle(out_os);
+  drawMainMenuOptions(out_os);
+  drawInputMenuPrompt(out_os, FlagInputErrornousChoice);
 }
 
 void receive_input_flags(std::istream &in_os) {
@@ -140,7 +140,7 @@ bool soloLoop() {
   // No choice in Menu selected, reset all flags...
   mainmenustatus = mainmenustatus_t{};
   clearScreen();
-  drawMainMenuGraphics();
+  drawMainMenuGraphics(std::cout);
   receive_input_flags(std::cin);
   process_MainMenu();
   return FlagInputErrornousChoice;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -24,24 +24,56 @@ void showScores() {
   s.printStats();
 }
 
-void input(int err) {
-  using Menu::startMenu;
+void drawMainMenuTitle() {
+  constexpr auto greetings_text = "Welcome to ";
+  constexpr auto gamename_text = "2048!";
+  constexpr auto sp = "  ";
+
+  std::ostringstream str_os;
+  std::ostringstream title_richtext;
+  title_richtext << bold_on << sp << greetings_text << blue << gamename_text
+                 << def << bold_off << "\n";
+
+  str_os << title_richtext.str();
+  std::cout << str_os.str();
+}
+
+void drawMainMenuOptions() {
+  constexpr auto menu_entry_text = R"(
+        1. Play a New Game
+        2. Continue Previous Game
+        3. View Highscores and Statistics
+        4. Exit
+
+)";
+
+  std::ostringstream str_os;
+  str_os << menu_entry_text;
+  std::cout << str_os.str();
+}
+
+void drawInputMenuPrompt(int err) {
   constexpr auto err_input_text = "Invalid input. Please try again.";
   constexpr auto prompt_choice_text = "Enter Choice: ";
   constexpr auto sp = "  ";
 
   std::ostringstream str_os;
   std::ostringstream err_input_richtext;
-  err_input_richtext << red << sp << err_input_text << def << "\n\n";
   std::ostringstream prompt_choice_richtext;
+
+  err_input_richtext << red << sp << err_input_text << def << "\n\n";
   prompt_choice_richtext << sp << prompt_choice_text;
 
   if (err) {
     str_os << err_input_richtext.str();
   }
-
   str_os << prompt_choice_richtext.str();
+
   std::cout << str_os.str();
+}
+
+void input() {
+  using Menu::startMenu;
   char c;
   std::cin >> c;
 
@@ -73,29 +105,12 @@ void input(int err) {
 namespace Menu {
 
 void startMenu(int err) {
-  constexpr auto greetings_text = "Welcome to ";
-  constexpr auto gamename_text = "2048!";
-  constexpr auto sp = "  ";
-
-  std::ostringstream str_os;
-  std::ostringstream title_richtext;
-  title_richtext << bold_on << sp << greetings_text << blue << gamename_text
-                 << def << bold_off << "\n";
-
-  constexpr auto menu_entry_text = R"(
-          1. Play a New Game
-          2. Continue Previous Game
-          3. View Highscores and Statistics
-          4. Exit
-
-)";
-
   clearScreen();
   drawAscii();
-  str_os << title_richtext.str();
-  str_os << menu_entry_text;
-  std::cout << str_os.str();
-  input(err);
+  drawMainMenuTitle();
+  drawMainMenuOptions();
+  drawInputMenuPrompt(err);
+  input();
 }
 
 } // namespace Menu

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -54,16 +54,18 @@ void drawMainMenuTitle() {
 }
 
 void drawMainMenuOptions() {
-  constexpr auto menu_entry_text = R"(
-        1. Play a New Game
-        2. Continue Previous Game
-        3. View Highscores and Statistics
-        4. Exit
-
-)";
+  const auto menu_list_txt = {"1. Play a New Game", "2. Continue Previous Game",
+                              "3. View Highscores and Statistics", "4. Exit"};
+  constexpr auto sp = "        ";
 
   std::ostringstream str_os;
-  str_os << menu_entry_text;
+
+  str_os << "\n";
+  for (const auto txt : menu_list_txt) {
+    str_os << sp << txt << "\n";
+  }
+  str_os << "\n";
+
   std::cout << str_os.str();
 }
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,37 +1,31 @@
 #include "menu.hpp"
 #include "color.hpp"
 #include "game.hpp"
+#include "global.hpp"
 #include "scores.hpp"
 #include <iostream>
 #include <sstream>
 
-void Menu::startMenu(int err) {
-  constexpr auto greetings_text = "Welcome to ";
-  constexpr auto gamename_text = "2048!";
-  constexpr auto sp = "  ";
+namespace {
 
-  std::ostringstream str_os;
-  std::ostringstream title_richtext;
-  title_richtext << bold_on << sp << greetings_text << blue << gamename_text
-                 << def << bold_off << "\n";
-
-  constexpr auto menu_entry_text = R"(
-          1. Play a New Game
-          2. Continue Previous Game
-          3. View Highscores and Statistics
-          4. Exit
-
-)";
-
-  clearScreen();
-  drawAscii();
-  str_os << title_richtext.str();
-  str_os << menu_entry_text;
-  std::cout << str_os.str();
-  input(err);
+void startGame() {
+  Game g;
+  g.startGame();
 }
 
-void Menu::input(int err) {
+void continueGame() {
+  Game g;
+  g.continueGame();
+}
+
+void showScores() {
+  Scoreboard s;
+  s.printScore();
+  s.printStats();
+}
+
+void input(int err) {
+  using Menu::startMenu;
   constexpr auto err_input_text = "Invalid input. Please try again.";
   constexpr auto prompt_choice_text = "Enter Choice: ";
   constexpr auto sp = "  ";
@@ -74,38 +68,34 @@ void Menu::input(int err) {
   }
 }
 
-void Menu::startGame() {
+} // namespace
 
-  Game g;
-  g.startGame();
+namespace Menu {
+
+void startMenu(int err) {
+  constexpr auto greetings_text = "Welcome to ";
+  constexpr auto gamename_text = "2048!";
+  constexpr auto sp = "  ";
+
+  std::ostringstream str_os;
+  std::ostringstream title_richtext;
+  title_richtext << bold_on << sp << greetings_text << blue << gamename_text
+                 << def << bold_off << "\n";
+
+  constexpr auto menu_entry_text = R"(
+          1. Play a New Game
+          2. Continue Previous Game
+          3. View Highscores and Statistics
+          4. Exit
+
+)";
+
+  clearScreen();
+  drawAscii();
+  str_os << title_richtext.str();
+  str_os << menu_entry_text;
+  std::cout << str_os.str();
+  input(err);
 }
 
-void Menu::continueGame() {
-  Game g;
-  g.continueGame();
-}
-
-void Menu::showScores() {
-
-  Scoreboard s;
-  s.printScore();
-  s.printStats();
-}
-
-void drawAscii() {
-  constexpr auto title_card_2048 = R"(
-   /\\\\\\\\\          /\\\\\\\                /\\\         /\\\\\\\\\
-  /\\\///////\\\      /\\\/////\\\            /\\\\\       /\\\///////\\\
-  \///      \//\\\    /\\\    \//\\\         /\\\/\\\      \/\\\     \/\\\
-             /\\\/    \/\\\     \/\\\       /\\\/\/\\\      \///\\\\\\\\\/
-           /\\\//      \/\\\     \/\\\     /\\\/  \/\\\       /\\\///////\\\
-         /\\\//         \/\\\     \/\\\   /\\\\\\\\\\\\\\\\   /\\\      \//\\\
-        /\\\/            \//\\\    /\\\   \///////////\\\//   \//\\\      /\\\
-        /\\\\\\\\\\\\\\\   \///\\\\\\\/              \/\\\      \///\\\\\\\\\/
-        \///////////////      \///////                \///         \/////////
-  )";
-  std::ostringstream title_card_richtext;
-  title_card_richtext << green << bold_on << title_card_2048 << bold_off << def;
-  title_card_richtext << "\n\n\n";
-  std::cout << title_card_richtext.str();
-}
+} // namespace Menu

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -96,11 +96,11 @@ void drawMainMenuGraphics() {
   drawInputMenuPrompt(FlagInputErrornousChoice);
 }
 
-void input() {
+void receive_input_flags(std::istream &in_os) {
   // Reset ErrornousChoice flag...
   FlagInputErrornousChoice = bool{};
   char c;
-  std::cin >> c;
+  in_os >> c;
 
   switch (c) {
   case '1':
@@ -141,7 +141,7 @@ bool soloLoop() {
   mainmenustatus = mainmenustatus_t{};
   clearScreen();
   drawMainMenuGraphics();
-  input();
+  receive_input_flags(std::cin);
   process_MainMenu();
   return FlagInputErrornousChoice;
 }

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -69,21 +69,29 @@ void drawMainMenuOptions(std::ostream &out_os) {
   out_os << str_os.str();
 }
 
-void drawInputMenuPrompt(std::ostream &out_os, bool err) {
-  constexpr auto err_input_text = "Invalid input. Please try again.";
+void drawInputMenuErrorInvalidInput(std::ostream &out_os, bool err) {
+  if (err) {
+    constexpr auto err_input_text = "Invalid input. Please try again.";
+    constexpr auto sp = "  ";
+
+    std::ostringstream str_os;
+    std::ostringstream err_input_richtext;
+    err_input_richtext << red << sp << err_input_text << def << "\n\n";
+
+    str_os << err_input_richtext.str();
+    out_os << str_os.str();
+  }
+}
+
+void drawInputMenuPrompt(std::ostream &out_os) {
   constexpr auto prompt_choice_text = "Enter Choice: ";
   constexpr auto sp = "  ";
 
   std::ostringstream str_os;
-  std::ostringstream err_input_richtext;
   std::ostringstream prompt_choice_richtext;
 
-  err_input_richtext << red << sp << err_input_text << def << "\n\n";
   prompt_choice_richtext << sp << prompt_choice_text;
 
-  if (err) {
-    str_os << err_input_richtext.str();
-  }
   str_os << prompt_choice_richtext.str();
 
   out_os << str_os.str();
@@ -93,7 +101,9 @@ void drawMainMenuGraphics(std::ostream &out_os) {
   drawAscii();
   drawMainMenuTitle(out_os);
   drawMainMenuOptions(out_os);
-  drawInputMenuPrompt(out_os, FlagInputErrornousChoice);
+  // Only outputs if there is an input error...
+  drawInputMenuErrorInvalidInput(out_os, FlagInputErrornousChoice);
+  drawInputMenuPrompt(out_os);
 }
 
 void receive_input_flags(std::istream &in_os) {


### PR DESCRIPTION
This PR cleans up the API to call the _"Main Menu"_ for _2048.cpp_.

One only just needs to add `menu.hpp` and to call `Menu::startMenu()`.

For example:
```cpp
#include "menu.hpp"
int main() {
  Menu::startMenu();
}
```

Functions needed for the _2048.cpp's Main Menu_ are contained within _(menu.cpp's)_ own anonymous namespace.