### PR TITLE
Fix: Convert Stats class to a namespaced area

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -441,7 +441,7 @@ void Game::statistics() const {
 }
 
 void Game::saveStats() const {
-  Stats stats;
+  total_game_stats_t stats;
   // Need some sort of stats data values only.
   // No need to care if file loaded successfully or not...
   std::tie(std::ignore, stats) =
@@ -713,7 +713,7 @@ ull Game::setBoardSize() {
 }
 
 void Game::startGame() {
-  Stats stats;
+  total_game_stats_t stats;
   bool stats_file_loaded{};
   std::tie(stats_file_loaded, stats) =
       loadFromFileStatistics("../data/statistics.txt");
@@ -730,7 +730,7 @@ void Game::startGame() {
 }
 
 void Game::continueGame() {
-  Stats stats;
+  total_game_stats_t stats;
   bool stats_file_loaded{};
   std::tie(stats_file_loaded, stats) =
       loadFromFileStatistics("../data/statistics.txt");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -452,12 +452,7 @@ void Game::saveStats() const {
   stats.totalDuration += duration;
 
   std::fstream statistics("../data/statistics.txt");
-  statistics << stats.bestScore << std::endl
-             << stats.gameCount << std::endl
-             << stats.winCount << std::endl
-             << stats.totalMoveCount << std::endl
-             << stats.totalDuration;
-
+  statistics << stats;
   statistics.close();
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -444,7 +444,7 @@ void Game::saveStats() const {
   Stats stats;
   // Need some sort of stats data values only.
   // No need to care if file loaded successfully or not...
-  std::tie(std::ignore, stats) = collectStatistics();
+  std::tie(std::ignore, stats) = loadFromFileStatistics();
   stats.bestScore = stats.bestScore < gamePlayBoard.score ?
                         gamePlayBoard.score :
                         stats.bestScore;
@@ -716,7 +716,7 @@ ull Game::setBoardSize() {
 void Game::startGame() {
   Stats stats;
   bool stats_file_loaded{};
-  std::tie(stats_file_loaded, stats) = collectStatistics();
+  std::tie(stats_file_loaded, stats) = loadFromFileStatistics();
   if (stats_file_loaded) {
     bestScore = stats.bestScore;
   }
@@ -732,7 +732,7 @@ void Game::startGame() {
 void Game::continueGame() {
   Stats stats;
   bool stats_file_loaded{};
-  std::tie(stats_file_loaded, stats) = collectStatistics();
+  std::tie(stats_file_loaded, stats) = loadFromFileStatistics();
   if (stats_file_loaded) {
     bestScore = stats.bestScore;
   }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -442,7 +442,7 @@ void Game::statistics() const {
 
 void Game::saveStats() const {
   Stats stats;
-  stats.collectStatistics();
+  collectStatistics(stats);
   stats.bestScore = stats.bestScore < gamePlayBoard.score ?
                         gamePlayBoard.score :
                         stats.bestScore;
@@ -714,7 +714,7 @@ ull Game::setBoardSize() {
 void Game::startGame() {
 
   Stats stats;
-  if (stats.collectStatistics()) {
+  if (collectStatistics(stats)) {
     bestScore = stats.bestScore;
   }
 
@@ -729,7 +729,7 @@ void Game::startGame() {
 void Game::continueGame() {
 
   Stats stats;
-  if (stats.collectStatistics()) {
+  if (collectStatistics(stats)) {
     bestScore = stats.bestScore;
   }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -454,9 +454,7 @@ void Game::saveStats() const {
   stats.totalMoveCount += gamePlayBoard.MoveCount();
   stats.totalDuration += duration;
 
-  std::fstream statistics("../data/statistics.txt");
-  statistics << stats;
-  statistics.close();
+  saveToFileStatistics("../data/statistics.txt", stats);
 }
 
 void Game::saveScore() const {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -444,7 +444,8 @@ void Game::saveStats() const {
   Stats stats;
   // Need some sort of stats data values only.
   // No need to care if file loaded successfully or not...
-  std::tie(std::ignore, stats) = loadFromFileStatistics();
+  std::tie(std::ignore, stats) =
+      loadFromFileStatistics("../data/statistics.txt");
   stats.bestScore = stats.bestScore < gamePlayBoard.score ?
                         gamePlayBoard.score :
                         stats.bestScore;
@@ -716,7 +717,8 @@ ull Game::setBoardSize() {
 void Game::startGame() {
   Stats stats;
   bool stats_file_loaded{};
-  std::tie(stats_file_loaded, stats) = loadFromFileStatistics();
+  std::tie(stats_file_loaded, stats) =
+      loadFromFileStatistics("../data/statistics.txt");
   if (stats_file_loaded) {
     bestScore = stats.bestScore;
   }
@@ -732,7 +734,8 @@ void Game::startGame() {
 void Game::continueGame() {
   Stats stats;
   bool stats_file_loaded{};
-  std::tie(stats_file_loaded, stats) = loadFromFileStatistics();
+  std::tie(stats_file_loaded, stats) =
+      loadFromFileStatistics("../data/statistics.txt");
   if (stats_file_loaded) {
     bestScore = stats.bestScore;
   }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -441,6 +441,7 @@ void Game::statistics() const {
 }
 
 void Game::saveStats() const {
+  using namespace Statistics;
   total_game_stats_t stats;
   // Need some sort of stats data values only.
   // No need to care if file loaded successfully or not...
@@ -713,6 +714,7 @@ ull Game::setBoardSize() {
 }
 
 void Game::startGame() {
+  using namespace Statistics;
   total_game_stats_t stats;
   bool stats_file_loaded{};
   std::tie(stats_file_loaded, stats) =
@@ -730,6 +732,7 @@ void Game::startGame() {
 }
 
 void Game::continueGame() {
+  using namespace Statistics;
   total_game_stats_t stats;
   bool stats_file_loaded{};
   std::tie(stats_file_loaded, stats) =

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -442,7 +442,9 @@ void Game::statistics() const {
 
 void Game::saveStats() const {
   Stats stats;
-  collectStatistics(stats);
+  // Need some sort of stats data values only.
+  // No need to care if file loaded successfully or not...
+  std::tie(std::ignore, stats) = collectStatistics();
   stats.bestScore = stats.bestScore < gamePlayBoard.score ?
                         gamePlayBoard.score :
                         stats.bestScore;
@@ -712,9 +714,10 @@ ull Game::setBoardSize() {
 }
 
 void Game::startGame() {
-
   Stats stats;
-  if (collectStatistics(stats)) {
+  bool stats_file_loaded{};
+  std::tie(stats_file_loaded, stats) = collectStatistics();
+  if (stats_file_loaded) {
     bestScore = stats.bestScore;
   }
 
@@ -727,9 +730,10 @@ void Game::startGame() {
 }
 
 void Game::continueGame() {
-
   Stats stats;
-  if (collectStatistics(stats)) {
+  bool stats_file_loaded{};
+  std::tie(stats_file_loaded, stats) = collectStatistics();
+  if (stats_file_loaded) {
     bestScore = stats.bestScore;
   }
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -39,6 +39,11 @@ void getInput(char &c) {
 
 #endif
 
+void wait_for_any_letter_input(std::istream &is) {
+  char c;
+  is >> c;
+}
+
 void newline(int n) {
   for (int i = 0; i < n; i++) {
     std::cout << "\n";

--- a/src/headers/global.hpp
+++ b/src/headers/global.hpp
@@ -5,6 +5,7 @@
 
 using ull = unsigned long long;
 void getInput(char &);
+void wait_for_any_letter_input(std::istream &is);
 void newline(int n = 1);
 void clearScreen();
 void drawAscii();

--- a/src/headers/scores.hpp
+++ b/src/headers/scores.hpp
@@ -30,7 +30,6 @@ public:
   long long moveCount;
   double duration;
   void printScore();
-  void printStats();
   void save();
 };
 #endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -6,7 +6,6 @@
 
 class Stats {
 public:
-  bool collectStatistics();
   ull bestScore;
   ull totalMoveCount;
   int gameCount;
@@ -17,5 +16,6 @@ public:
   friend std::ostream& operator<<(std::ostream& os, Stats &s);
 };
 
+bool collectStatistics(Stats &stats);
 
 #endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <tuple>
 
+namespace Statistics {
 struct total_game_stats_t {
   ull bestScore{};
   ull totalMoveCount{};
@@ -16,10 +17,11 @@ struct total_game_stats_t {
 
 using load_stats_status_t = std::tuple<bool, total_game_stats_t>;
 
-std::istream &operator>>(std::istream &is, total_game_stats_t &s);
-std::ostream &operator<<(std::ostream &os, total_game_stats_t &s);
-
 load_stats_status_t loadFromFileStatistics(std::string filename);
 bool saveToFileStatistics(std::string filename, total_game_stats_t s);
+} // namespace Statistics
+
+std::istream &operator>>(std::istream &is, Statistics::total_game_stats_t &s);
+std::ostream &operator<<(std::ostream &os, Statistics::total_game_stats_t &s);
 
 #endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -19,7 +19,7 @@ using load_stats_status_t = std::tuple<bool, total_game_stats_t>;
 
 load_stats_status_t loadFromFileStatistics(std::string filename);
 bool saveToFileStatistics(std::string filename, total_game_stats_t s);
-void prettyPrintStats();
+void prettyPrintStats(std::ostream &os);
 } // namespace Statistics
 
 std::istream &operator>>(std::istream &is, Statistics::total_game_stats_t &s);

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -20,5 +20,6 @@ std::istream &operator>>(std::istream &is, Stats &s);
 std::ostream &operator<<(std::ostream &os, Stats &s);
 
 load_stats_status_t loadFromFileStatistics(std::string filename);
+bool saveToFileStatistics(std::string filename, Stats s);
 
 #endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -2,6 +2,7 @@
 #define STATISTICS_H
 
 #include "global.hpp"
+#include <iosfwd>
 
 class Stats {
 public:
@@ -11,6 +12,10 @@ public:
   int gameCount;
   double totalDuration;
   int winCount;
+
+  friend std::istream& operator>>(std::istream& is, Stats &s);
+  friend std::ostream& operator<<(std::ostream& os, Stats &s);
 };
+
 
 #endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -3,6 +3,7 @@
 
 #include "global.hpp"
 #include <iosfwd>
+#include <string>
 #include <tuple>
 
 struct Stats {
@@ -18,6 +19,6 @@ using load_stats_status_t = std::tuple<bool, Stats>;
 std::istream &operator>>(std::istream &is, Stats &s);
 std::ostream &operator<<(std::ostream &os, Stats &s);
 
-load_stats_status_t loadFromFileStatistics();
+load_stats_status_t loadFromFileStatistics(std::string filename);
 
 #endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -18,6 +18,6 @@ using load_stats_status_t = std::tuple<bool, Stats>;
 std::istream &operator>>(std::istream &is, Stats &s);
 std::ostream &operator<<(std::ostream &os, Stats &s);
 
-load_stats_status_t collectStatistics();
+load_stats_status_t loadFromFileStatistics();
 
 #endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -19,6 +19,7 @@ using load_stats_status_t = std::tuple<bool, total_game_stats_t>;
 
 load_stats_status_t loadFromFileStatistics(std::string filename);
 bool saveToFileStatistics(std::string filename, total_game_stats_t s);
+void prettyPrintStats();
 } // namespace Statistics
 
 std::istream &operator>>(std::istream &is, Statistics::total_game_stats_t &s);

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -3,6 +3,7 @@
 
 #include "global.hpp"
 #include <iosfwd>
+#include <tuple>
 
 struct Stats {
   ull bestScore{};
@@ -12,9 +13,11 @@ struct Stats {
   int winCount{};
 };
 
+using load_stats_status_t = std::tuple<bool, Stats>;
+
 std::istream &operator>>(std::istream &is, Stats &s);
 std::ostream &operator<<(std::ostream &os, Stats &s);
 
-bool collectStatistics(Stats &stats);
+load_stats_status_t collectStatistics();
 
 #endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -4,17 +4,16 @@
 #include "global.hpp"
 #include <iosfwd>
 
-class Stats {
-public:
-  ull bestScore;
-  ull totalMoveCount;
-  int gameCount;
-  double totalDuration;
-  int winCount;
-
-  friend std::istream& operator>>(std::istream& is, Stats &s);
-  friend std::ostream& operator<<(std::ostream& os, Stats &s);
+struct Stats {
+  ull bestScore{};
+  ull totalMoveCount{};
+  int gameCount{};
+  double totalDuration{};
+  int winCount{};
 };
+
+std::istream &operator>>(std::istream &is, Stats &s);
+std::ostream &operator<<(std::ostream &os, Stats &s);
 
 bool collectStatistics(Stats &stats);
 

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <tuple>
 
-struct Stats {
+struct total_game_stats_t {
   ull bestScore{};
   ull totalMoveCount{};
   int gameCount{};
@@ -14,12 +14,12 @@ struct Stats {
   int winCount{};
 };
 
-using load_stats_status_t = std::tuple<bool, Stats>;
+using load_stats_status_t = std::tuple<bool, total_game_stats_t>;
 
-std::istream &operator>>(std::istream &is, Stats &s);
-std::ostream &operator<<(std::ostream &os, Stats &s);
+std::istream &operator>>(std::istream &is, total_game_stats_t &s);
+std::ostream &operator<<(std::ostream &os, total_game_stats_t &s);
 
 load_stats_status_t loadFromFileStatistics(std::string filename);
-bool saveToFileStatistics(std::string filename, Stats s);
+bool saveToFileStatistics(std::string filename, total_game_stats_t s);
 
 #endif

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -3,6 +3,7 @@
 #include "game.hpp"
 #include "global.hpp"
 #include "scores.hpp"
+#include "statistics.hpp"
 #include <array>
 #include <iostream>
 #include <sstream>
@@ -36,7 +37,8 @@ void continueGame() {
 void showScores() {
   Scoreboard s;
   s.printScore();
-  s.printStats();
+  Statistics::prettyPrintStats();
+  exit(EXIT_SUCCESS);
 }
 
 void drawMainMenuTitle(std::ostream &out_os) {

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -37,7 +37,8 @@ void continueGame() {
 void showScores() {
   Scoreboard s;
   s.printScore();
-  Statistics::prettyPrintStats();
+  Statistics::prettyPrintStats(std::cout);
+  wait_for_any_letter_input(std::cin);
   exit(EXIT_SUCCESS);
 }
 

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -106,6 +106,7 @@ void Scoreboard::printScore() {
 }
 
 void Scoreboard::printStats() {
+  using namespace Statistics;
   constexpr auto stats_title_text = "STATISTICS";
   constexpr auto divider_text = "──────────";
   constexpr auto header_border_text = "┌────────────────────┬─────────────┐";

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -119,7 +119,7 @@ void Scoreboard::printStats() {
 
   std::ostringstream stats_richtext;
 
-  Stats stats;
+  total_game_stats_t stats;
   bool stats_file_loaded{};
   std::tie(stats_file_loaded, stats) =
       loadFromFileStatistics("../data/statistics.txt");

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -117,9 +117,12 @@ void Scoreboard::printStats() {
   constexpr auto any_key_exit_text = "Press any key to exit: ";
   constexpr auto sp = "  ";
 
-  Stats stats;
   std::ostringstream stats_richtext;
-  if (collectStatistics(stats)) {
+
+  Stats stats;
+  bool stats_file_loaded{};
+  std::tie(stats_file_loaded, stats) = collectStatistics();
+  if (stats_file_loaded) {
     constexpr auto num_of_stats_attributes_text = 5;
     auto data_stats = std::array<std::string, num_of_stats_attributes_text>{};
     data_stats = {

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -119,7 +119,7 @@ void Scoreboard::printStats() {
 
   Stats stats;
   std::ostringstream stats_richtext;
-  if (stats.collectStatistics()) {
+  if (collectStatistics(stats)) {
     constexpr auto num_of_stats_attributes_text = 5;
     auto data_stats = std::array<std::string, num_of_stats_attributes_text>{};
     data_stats = {

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -121,7 +121,8 @@ void Scoreboard::printStats() {
 
   Stats stats;
   bool stats_file_loaded{};
-  std::tie(stats_file_loaded, stats) = loadFromFileStatistics();
+  std::tie(stats_file_loaded, stats) =
+      loadFromFileStatistics("../data/statistics.txt");
   if (stats_file_loaded) {
     constexpr auto num_of_stats_attributes_text = 5;
     auto data_stats = std::array<std::string, num_of_stats_attributes_text>{};

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -1,7 +1,6 @@
 #include "scores.hpp"
 #include "color.hpp"
 #include "menu.hpp"
-#include "statistics.hpp"
 #include <algorithm>
 #include <array>
 #include <fstream>
@@ -103,67 +102,6 @@ void Scoreboard::printScore() {
   }
   str_os << "\n\n";
   std::cout << str_os.str();
-}
-
-void Scoreboard::printStats() {
-  using namespace Statistics;
-  constexpr auto stats_title_text = "STATISTICS";
-  constexpr auto divider_text = "──────────";
-  constexpr auto header_border_text = "┌────────────────────┬─────────────┐";
-  constexpr auto footer_border_text = "└────────────────────┴─────────────┘";
-  const auto stats_attributes_text = {"Best Score", "Game Count",
-                                      "Number of Wins", "Total Moves Played",
-                                      "Total Duration"};
-  constexpr auto no_save_text = "No saved statistics.";
-  constexpr auto any_key_exit_text = "Press any key to exit: ";
-  constexpr auto sp = "  ";
-
-  std::ostringstream stats_richtext;
-
-  total_game_stats_t stats;
-  bool stats_file_loaded{};
-  std::tie(stats_file_loaded, stats) =
-      loadFromFileStatistics("../data/statistics.txt");
-  if (stats_file_loaded) {
-    constexpr auto num_of_stats_attributes_text = 5;
-    auto data_stats = std::array<std::string, num_of_stats_attributes_text>{};
-    data_stats = {
-        std::to_string(stats.bestScore), std::to_string(stats.gameCount),
-        std::to_string(stats.winCount), std::to_string(stats.totalMoveCount),
-        secondsFormat(stats.totalDuration)};
-
-    auto counter{0};
-    const auto populate_stats_info = [data_stats, stats_attributes_text,
-                                      &counter,
-                                      &stats_richtext](const std::string) {
-      stats_richtext << sp << "│ " << bold_on << std::left << std::setw(18)
-                     << std::begin(stats_attributes_text)[counter] << bold_off
-                     << " │ " << std::right << std::setw(11)
-                     << data_stats[counter] << " │"
-                     << "\n";
-      counter++;
-    };
-
-    stats_richtext << green << bold_on << sp << stats_title_text << bold_off
-                   << def << "\n";
-    stats_richtext << green << bold_on << sp << divider_text << bold_off << def
-                   << "\n";
-    stats_richtext << sp << header_border_text << "\n";
-    std::for_each(std::begin(stats_attributes_text),
-                  std::end(stats_attributes_text), populate_stats_info);
-    stats_richtext << sp << footer_border_text << "\n";
-
-  } else {
-    stats_richtext << sp << no_save_text << "\n";
-  }
-
-  stats_richtext << "\n\n\n";
-  stats_richtext << sp << any_key_exit_text;
-
-  std::cout << stats_richtext.str();
-  char c;
-  std::cin >> c;
-  exit(EXIT_SUCCESS);
 }
 
 void Scoreboard::padding(std::string name) {

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -121,7 +121,7 @@ void Scoreboard::printStats() {
 
   Stats stats;
   bool stats_file_loaded{};
-  std::tie(stats_file_loaded, stats) = collectStatistics();
+  std::tie(stats_file_loaded, stats) = loadFromFileStatistics();
   if (stats_file_loaded) {
     constexpr auto num_of_stats_attributes_text = 5;
     auto data_stats = std::array<std::string, num_of_stats_attributes_text>{};

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -1,14 +1,14 @@
 #include "statistics.hpp"
 #include <fstream>
 
-bool Stats::collectStatistics() {
+bool collectStatistics(Stats &stats) {
 
   std::ifstream statistics("../data/statistics.txt");
   if (statistics.fail()) {
     return false;
   }
 
-  statistics >> *this;
+  statistics >> stats;
   return true;
 }
 

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -4,7 +4,6 @@
 #include <array>
 #include <fstream>
 #include <iomanip>
-#include <iostream>
 #include <sstream>
 
 namespace Statistics {
@@ -38,7 +37,7 @@ bool saveToFileStatistics(std::string filename, total_game_stats_t s) {
   return generateFilefromStatsData(filedata, s);
 }
 
-void prettyPrintStats() {
+void prettyPrintStats(std::ostream &os) {
   constexpr auto stats_title_text = "STATISTICS";
   constexpr auto divider_text = "──────────";
   constexpr auto header_border_text = "┌────────────────────┬─────────────┐";
@@ -92,9 +91,7 @@ void prettyPrintStats() {
   stats_richtext << "\n\n\n";
   stats_richtext << sp << any_key_exit_text;
 
-  std::cout << stats_richtext.str();
-  char c;
-  std::cin >> c;
+  os << stats_richtext.str();
 }
 
 } // namespace Statistics

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -11,13 +11,13 @@ Stats loadFromFileStatistics(std::istream &is) {
 
 } // namespace
 
-bool collectStatistics(Stats &stats) {
+load_stats_status_t collectStatistics() {
   std::ifstream statistics("../data/statistics.txt");
   if (statistics) {
-    stats = loadFromFileStatistics(statistics);
-    return true;
+    Stats stats = loadFromFileStatistics(statistics);
+    return load_stats_status_t{true, stats};
   }
-  return false;
+  return load_stats_status_t{false, Stats{}};
 }
 
 std::istream &operator>>(std::istream &is, Stats &s) {

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -1,6 +1,8 @@
 #include "statistics.hpp"
 #include <fstream>
 
+namespace Statistics {
+
 namespace {
 
 total_game_stats_t generateStatsFromInputData(std::istream &is) {
@@ -29,6 +31,10 @@ bool saveToFileStatistics(std::string filename, total_game_stats_t s) {
   std::ofstream filedata(filename);
   return generateFilefromStatsData(filedata, s);
 }
+
+} // namespace Statistics
+
+using namespace Statistics;
 
 std::istream &operator>>(std::istream &is, total_game_stats_t &s) {
   is >> s.bestScore >> s.gameCount >> s.winCount >> s.totalMoveCount >>

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -9,6 +9,11 @@ Stats generateStatsFromInputData(std::istream &is) {
   return stats;
 }
 
+bool generateFilefromStatsData(std::ostream &os, Stats stats) {
+  os << stats;
+  return true;
+}
+
 } // namespace
 
 load_stats_status_t loadFromFileStatistics(std::string filename) {
@@ -18,6 +23,11 @@ load_stats_status_t loadFromFileStatistics(std::string filename) {
     return load_stats_status_t{true, stats};
   }
   return load_stats_status_t{false, Stats{}};
+}
+
+bool saveToFileStatistics(std::string filename, Stats s) {
+  std::ofstream filedata(filename);
+  return generateFilefromStatsData(filedata, s);
 }
 
 std::istream &operator>>(std::istream &is, Stats &s) {

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -3,13 +3,13 @@
 
 namespace {
 
-Stats generateStatsFromInputData(std::istream &is) {
-  Stats stats;
+total_game_stats_t generateStatsFromInputData(std::istream &is) {
+  total_game_stats_t stats;
   is >> stats;
   return stats;
 }
 
-bool generateFilefromStatsData(std::ostream &os, Stats stats) {
+bool generateFilefromStatsData(std::ostream &os, total_game_stats_t stats) {
   os << stats;
   return true;
 }
@@ -19,24 +19,24 @@ bool generateFilefromStatsData(std::ostream &os, Stats stats) {
 load_stats_status_t loadFromFileStatistics(std::string filename) {
   std::ifstream statistics(filename);
   if (statistics) {
-    Stats stats = generateStatsFromInputData(statistics);
+    total_game_stats_t stats = generateStatsFromInputData(statistics);
     return load_stats_status_t{true, stats};
   }
-  return load_stats_status_t{false, Stats{}};
+  return load_stats_status_t{false, total_game_stats_t{}};
 }
 
-bool saveToFileStatistics(std::string filename, Stats s) {
+bool saveToFileStatistics(std::string filename, total_game_stats_t s) {
   std::ofstream filedata(filename);
   return generateFilefromStatsData(filedata, s);
 }
 
-std::istream &operator>>(std::istream &is, Stats &s) {
+std::istream &operator>>(std::istream &is, total_game_stats_t &s) {
   is >> s.bestScore >> s.gameCount >> s.winCount >> s.totalMoveCount >>
       s.totalDuration;
   return is;
 }
 
-std::ostream &operator<<(std::ostream &os, Stats &s) {
+std::ostream &operator<<(std::ostream &os, total_game_stats_t &s) {
   os << s.bestScore << "\n"
      << s.gameCount << "\n"
      << s.winCount << "\n"

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -3,7 +3,7 @@
 
 namespace {
 
-Stats loadFromFileStatistics(std::istream &is) {
+Stats generateStatsFromInputData(std::istream &is) {
   Stats stats;
   is >> stats;
   return stats;
@@ -11,10 +11,10 @@ Stats loadFromFileStatistics(std::istream &is) {
 
 } // namespace
 
-load_stats_status_t collectStatistics() {
+load_stats_status_t loadFromFileStatistics() {
   std::ifstream statistics("../data/statistics.txt");
   if (statistics) {
-    Stats stats = loadFromFileStatistics(statistics);
+    Stats stats = generateStatsFromInputData(statistics);
     return load_stats_status_t{true, stats};
   }
   return load_stats_status_t{false, Stats{}};

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -1,15 +1,23 @@
 #include "statistics.hpp"
 #include <fstream>
 
+namespace {
+
+Stats loadFromFileStatistics(std::istream &is) {
+  Stats stats;
+  is >> stats;
+  return stats;
+}
+
+} // namespace
+
 bool collectStatistics(Stats &stats) {
-
   std::ifstream statistics("../data/statistics.txt");
-  if (statistics.fail()) {
-    return false;
+  if (statistics) {
+    stats = loadFromFileStatistics(statistics);
+    return true;
   }
-
-  statistics >> stats;
-  return true;
+  return false;
 }
 
 std::istream &operator>>(std::istream &is, Stats &s) {

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -1,5 +1,11 @@
 #include "statistics.hpp"
+#include "color.hpp"
+#include <algorithm>
+#include <array>
 #include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
 namespace Statistics {
 
@@ -30,6 +36,65 @@ load_stats_status_t loadFromFileStatistics(std::string filename) {
 bool saveToFileStatistics(std::string filename, total_game_stats_t s) {
   std::ofstream filedata(filename);
   return generateFilefromStatsData(filedata, s);
+}
+
+void prettyPrintStats() {
+  constexpr auto stats_title_text = "STATISTICS";
+  constexpr auto divider_text = "──────────";
+  constexpr auto header_border_text = "┌────────────────────┬─────────────┐";
+  constexpr auto footer_border_text = "└────────────────────┴─────────────┘";
+  const auto stats_attributes_text = {"Best Score", "Game Count",
+                                      "Number of Wins", "Total Moves Played",
+                                      "Total Duration"};
+  constexpr auto no_save_text = "No saved statistics.";
+  constexpr auto any_key_exit_text = "Press any key to exit: ";
+  constexpr auto sp = "  ";
+
+  std::ostringstream stats_richtext;
+
+  total_game_stats_t stats;
+  bool stats_file_loaded{};
+  std::tie(stats_file_loaded, stats) =
+      loadFromFileStatistics("../data/statistics.txt");
+  if (stats_file_loaded) {
+    constexpr auto num_of_stats_attributes_text = 5;
+    auto data_stats = std::array<std::string, num_of_stats_attributes_text>{};
+    data_stats = {
+        std::to_string(stats.bestScore), std::to_string(stats.gameCount),
+        std::to_string(stats.winCount), std::to_string(stats.totalMoveCount),
+        secondsFormat(stats.totalDuration)};
+
+    auto counter{0};
+    const auto populate_stats_info = [data_stats, stats_attributes_text,
+                                      &counter,
+                                      &stats_richtext](const std::string) {
+      stats_richtext << sp << "│ " << bold_on << std::left << std::setw(18)
+                     << std::begin(stats_attributes_text)[counter] << bold_off
+                     << " │ " << std::right << std::setw(11)
+                     << data_stats[counter] << " │"
+                     << "\n";
+      counter++;
+    };
+
+    stats_richtext << green << bold_on << sp << stats_title_text << bold_off
+                   << def << "\n";
+    stats_richtext << green << bold_on << sp << divider_text << bold_off << def
+                   << "\n";
+    stats_richtext << sp << header_border_text << "\n";
+    std::for_each(std::begin(stats_attributes_text),
+                  std::end(stats_attributes_text), populate_stats_info);
+    stats_richtext << sp << footer_border_text << "\n";
+
+  } else {
+    stats_richtext << sp << no_save_text << "\n";
+  }
+
+  stats_richtext << "\n\n\n";
+  stats_richtext << sp << any_key_exit_text;
+
+  std::cout << stats_richtext.str();
+  char c;
+  std::cin >> c;
 }
 
 } // namespace Statistics

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -8,7 +8,21 @@ bool Stats::collectStatistics() {
     return false;
   }
 
-  statistics >> bestScore >> gameCount >> winCount >> totalMoveCount >>
-      totalDuration;
+  statistics >> *this;
   return true;
+}
+
+std::istream &operator>>(std::istream &is, Stats &s) {
+  is >> s.bestScore >> s.gameCount >> s.winCount >> s.totalMoveCount >>
+      s.totalDuration;
+  return is;
+}
+
+std::ostream &operator<<(std::ostream &os, Stats &s) {
+  os << s.bestScore << "\n"
+     << s.gameCount << "\n"
+     << s.winCount << "\n"
+     << s.totalMoveCount << "\n"
+     << s.totalDuration;
+  return os;
 }

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -11,8 +11,8 @@ Stats generateStatsFromInputData(std::istream &is) {
 
 } // namespace
 
-load_stats_status_t loadFromFileStatistics() {
-  std::ifstream statistics("../data/statistics.txt");
+load_stats_status_t loadFromFileStatistics(std::string filename) {
+  std::ifstream statistics(filename);
   if (statistics) {
     Stats stats = generateStatsFromInputData(statistics);
     return load_stats_status_t{true, stats};


### PR DESCRIPTION
This PR does a few things:

* _Converts_ `Stats` class into a _simple struct datastructure_.
* _Renames_ `Stats` datatype to a more appropriate name: `total_game_stats_t`.
* _Adds the standard conventions_ of using "`operator`" functions to write `total_game_stats_t` data to some sort of "`std::{??}stream`".
* _Namespaces datatype and its helper functions_ to avoid name conflicts and to prepare for a future loading / saving PR.
* Made a _"Pretty Print"_ function to display datatype in a table-like form.