### PR TITLE
Fix: Convert Game class to a namespaced area

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)  # 3.7: CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT, 3.3: CXX_STANDARD
 project(2048 CXX)
 
-set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/global.cpp src/menu.cpp src/scores.cpp src/statistics.cpp)
+set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/global.cpp src/menu.cpp src/scores.cpp src/statistics.cpp src/tile.cpp)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   list(APPEND FLAGS -Wall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)  # 3.7: CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT, 3.3: CXX_STANDARD
 project(2048 CXX)
 
-set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/game-graphics.cpp src/global.cpp src/menu.cpp src/scores.cpp src/statistics.cpp src/tile.cpp)
+set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/game-graphics.cpp src/game-input.cpp src/global.cpp src/menu.cpp src/scores.cpp src/statistics.cpp src/tile.cpp)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   list(APPEND FLAGS -Wall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)  # 3.7: CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT, 3.3: CXX_STANDARD
 project(2048 CXX)
 
-set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/game-graphics.cpp src/game-input.cpp src/global.cpp src/loadresource.cpp src/menu.cpp src/scores.cpp src/statistics.cpp src/tile.cpp)
+set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/game-graphics.cpp src/game-input.cpp src/global.cpp src/loadresource.cpp src/menu.cpp src/saveresource.cpp src/scores.cpp src/statistics.cpp src/tile.cpp)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   list(APPEND FLAGS -Wall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)  # 3.7: CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT, 3.3: CXX_STANDARD
 project(2048 CXX)
 
-set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/game-graphics.cpp src/game-input.cpp src/global.cpp src/menu.cpp src/scores.cpp src/statistics.cpp src/tile.cpp)
+set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/game-graphics.cpp src/game-input.cpp src/global.cpp src/loadresource.cpp src/menu.cpp src/scores.cpp src/statistics.cpp src/tile.cpp)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   list(APPEND FLAGS -Wall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)  # 3.7: CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT, 3.3: CXX_STANDARD
 project(2048 CXX)
 
-set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/global.cpp src/menu.cpp src/scores.cpp src/statistics.cpp src/tile.cpp)
+set(SOURCES src/2048.cpp src/gameboard.cpp src/game.cpp src/game-graphics.cpp src/global.cpp src/menu.cpp src/scores.cpp src/statistics.cpp src/tile.cpp)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   list(APPEND FLAGS -Wall)

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ elif cxx.get_id() == 'intel'
 endif
 
 main_target_name = '2048'
-sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/global.cpp', 'src/menu.cpp', 'src/scores.cpp', 'src/statistics.cpp', 'src/tile.cpp']
+sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/game-graphics.cpp', 'src/global.cpp', 'src/menu.cpp', 'src/scores.cpp', 'src/statistics.cpp', 'src/tile.cpp']
 hdrs = include_directories('src/headers')
 
 executable(main_target_name, sources, 

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ elif cxx.get_id() == 'intel'
 endif
 
 main_target_name = '2048'
-sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/game-input.cpp', 'src/game-graphics.cpp', 'src/global.cpp', 'src/menu.cpp', 'src/scores.cpp', 'src/statistics.cpp', 'src/tile.cpp']
+sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/game-input.cpp', 'src/game-graphics.cpp', 'src/global.cpp', 'src/loadresource.cpp', 'src/menu.cpp', 'src/scores.cpp', 'src/statistics.cpp', 'src/tile.cpp']
 hdrs = include_directories('src/headers')
 
 executable(main_target_name, sources, 

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ elif cxx.get_id() == 'intel'
 endif
 
 main_target_name = '2048'
-sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/game-input.cpp', 'src/game-graphics.cpp', 'src/global.cpp', 'src/loadresource.cpp', 'src/menu.cpp', 'src/scores.cpp', 'src/statistics.cpp', 'src/tile.cpp']
+sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/game-input.cpp', 'src/game-graphics.cpp', 'src/global.cpp', 'src/loadresource.cpp', 'src/menu.cpp', 'src/saveresource.cpp', 'src/scores.cpp', 'src/statistics.cpp', 'src/tile.cpp']
 hdrs = include_directories('src/headers')
 
 executable(main_target_name, sources, 

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ elif cxx.get_id() == 'intel'
 endif
 
 main_target_name = '2048'
-sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/game-graphics.cpp', 'src/global.cpp', 'src/menu.cpp', 'src/scores.cpp', 'src/statistics.cpp', 'src/tile.cpp']
+sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/game-input.cpp', 'src/game-graphics.cpp', 'src/global.cpp', 'src/menu.cpp', 'src/scores.cpp', 'src/statistics.cpp', 'src/tile.cpp']
 hdrs = include_directories('src/headers')
 
 executable(main_target_name, sources, 

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ elif cxx.get_id() == 'intel'
 endif
 
 main_target_name = '2048'
-sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/global.cpp', 'src/menu.cpp', 'src/scores.cpp', 'src/statistics.cpp']
+sources = ['src/2048.cpp', 'src/gameboard.cpp', 'src/game.cpp', 'src/global.cpp', 'src/menu.cpp', 'src/scores.cpp', 'src/statistics.cpp', 'src/tile.cpp']
 hdrs = include_directories('src/headers')
 
 executable(main_target_name, sources, 

--- a/src/game-graphics.cpp
+++ b/src/game-graphics.cpp
@@ -1,0 +1,150 @@
+#include "game-graphics.hpp"
+#include "color.hpp"
+#include <sstream>
+
+namespace Game {
+namespace Graphics {
+std::string MessageScoreSavedPrompt() {
+  constexpr auto score_saved_text = "Score saved!";
+  constexpr auto sp = "  ";
+  std::ostringstream score_saved_richtext;
+  score_saved_richtext << "\n"
+                       << green << bold_on << sp << score_saved_text << bold_off
+                       << def << "\n";
+  return score_saved_richtext.str();
+}
+
+std::string AskForPlayerNamePrompt() {
+  constexpr auto score_prompt_text =
+      "Please enter your name to save this score: ";
+  constexpr auto sp = "  ";
+  std::ostringstream score_prompt_richtext;
+  score_prompt_richtext << bold_on << sp << score_prompt_text << bold_off;
+  return score_prompt_richtext.str();
+}
+
+std::string BoardInputPrompt() {
+  constexpr auto board_size_prompt_text =
+      "Enter gameboard size (NOTE: Scores and statistics will be saved only for the 4x4 gameboard): ";
+  constexpr auto sp = "  ";
+  std::ostringstream board_size_prompt_richtext;
+  board_size_prompt_richtext << bold_on << sp << board_size_prompt_text
+                             << bold_off;
+  return board_size_prompt_richtext.str();
+}
+
+std::string YouWinPrompt() {
+  constexpr auto win_game_text = "You win! Congratulations!";
+  constexpr auto sp = "  ";
+  std::ostringstream win_richtext;
+  win_richtext << green << bold_on << sp << win_game_text << def << bold_off
+               << "\n\n\n";
+  return win_richtext.str();
+}
+
+std::string GameOverPrompt() {
+  constexpr auto lose_game_text = "Game over! You lose.";
+  constexpr auto sp = "  ";
+  std::ostringstream lose_richtext;
+  lose_richtext << red << bold_on << sp << lose_game_text << def << bold_off
+                << "\n\n\n";
+  return lose_richtext.str();
+}
+
+std::string EndOfEndlessPrompt() {
+  constexpr auto endless_mode_text =
+      "End of endless mode! Thank you for playing!";
+  constexpr auto sp = "  ";
+  std::ostringstream endless_mode_richtext;
+  endless_mode_richtext << red << bold_on << sp << endless_mode_text << def
+                        << bold_off << "\n\n\n";
+  return endless_mode_richtext.str();
+}
+
+std::string QuestionEndOfWinningGamePrompt() {
+  constexpr auto win_but_what_next =
+      "You Won! Continue playing current game? [y/n]";
+  constexpr auto sp = "  ";
+  std::ostringstream win_richtext;
+  win_richtext << green << bold_on << sp << win_but_what_next << def << bold_off
+               << ": ";
+  return win_richtext.str();
+}
+
+std::string GameStateNowSavedPrompt() {
+  constexpr auto state_saved_text =
+      "The game has been saved. Feel free to take a break.";
+  constexpr auto sp = "  ";
+  std::ostringstream state_saved_richtext;
+  state_saved_richtext << green << bold_on << sp << state_saved_text << def
+                       << bold_off << "\n\n";
+  return state_saved_richtext.str();
+}
+
+std::string GameBoardNoSaveErrorPrompt() {
+  constexpr auto no_save_found_text =
+      "No saved game found. Starting a new game.";
+  constexpr auto sp = "  ";
+  std::ostringstream no_save_richtext;
+  no_save_richtext << red << bold_on << sp << no_save_found_text << def
+                   << bold_off << "\n\n";
+  return no_save_richtext.str();
+}
+
+std::string InvalidInputGameBoardErrorPrompt() {
+  constexpr auto invalid_prompt_text = "Invalid input. Please try again.";
+  constexpr auto sp = "  ";
+  std::ostringstream invalid_prompt_richtext;
+  invalid_prompt_richtext << red << sp << invalid_prompt_text << def << "\n\n";
+  return invalid_prompt_richtext.str();
+}
+
+std::string BoardSizeErrorPrompt() {
+  const auto invalid_prompt_text = {
+      "Invalid input. Gameboard size should range from ", " to ", "."};
+  //  constexpr auto num_of_invalid_prompt_text = 3;
+  constexpr auto sp = "  ";
+  std::ostringstream error_prompt_richtext;
+  error_prompt_richtext << red << sp << std::begin(invalid_prompt_text)[0]
+                        << MIN_GAME_BOARD_PLAY_SIZE
+                        << std::begin(invalid_prompt_text)[1]
+                        << MAX_GAME_BOARD_PLAY_SIZE
+                        << std::begin(invalid_prompt_text)[2] << def << "\n\n";
+  return error_prompt_richtext.str();
+}
+
+std::string InputCommandListPrompt() {
+  constexpr auto sp = "  ";
+  const auto input_commands_list_text = {
+      "W or K or ↑ => Up", "A or H or ← => Left", "S or J or ↓ => Down",
+      "D or L or → => Right", "Z or P => Save"};
+  std::ostringstream str_os;
+  for (const auto txt : input_commands_list_text) {
+    str_os << sp << txt << "\n";
+  }
+  return str_os.str();
+}
+
+std::string EndlessModeCommandListPrompt() {
+  constexpr auto sp = "  ";
+  const auto endless_mode_list_text = {"X => Quit Endless Mode"};
+  std::ostringstream str_os;
+  for (const auto txt : endless_mode_list_text) {
+    str_os << sp << txt << "\n";
+  }
+  return str_os.str();
+}
+
+std::string InputCommandListFooterPrompt() {
+  constexpr auto sp = "  ";
+  const auto input_commands_list_footer_text = {
+      "", "Press the keys to start and continue.", "\n"};
+  std::ostringstream str_os;
+  for (const auto txt : input_commands_list_footer_text) {
+    str_os << sp << txt << "\n";
+  }
+  return str_os.str();
+}
+
+} // namespace Graphics
+} // namespace Game

--- a/src/game-input.cpp
+++ b/src/game-input.cpp
@@ -1,0 +1,69 @@
+#include "game-input.hpp"
+#include "global.hpp"
+
+namespace Game {
+namespace Input {
+bool check_input_ansi(char c, intendedmove_t &intendedmove) {
+  using namespace Keypress::Code;
+  if (c == CODE_ANSI_TRIGGER_1) {
+    getKeypressDownInput(c);
+    if (c == CODE_ANSI_TRIGGER_2) {
+      getKeypressDownInput(c);
+      switch (c) {
+      case CODE_ANSI_UP:
+        intendedmove[FLAG_MOVE_UP] = true;
+        return false;
+      case CODE_ANSI_DOWN:
+        intendedmove[FLAG_MOVE_DOWN] = true;
+        return false;
+      case CODE_ANSI_RIGHT:
+        intendedmove[FLAG_MOVE_RIGHT] = true;
+        return false;
+      case CODE_ANSI_LEFT:
+        intendedmove[FLAG_MOVE_LEFT] = true;
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool check_input_vim(char c, intendedmove_t &intendedmove) {
+  using namespace Keypress::Code;
+  switch (toupper(c)) {
+  case CODE_VIM_UP:
+    intendedmove[FLAG_MOVE_UP] = true;
+    return false;
+  case CODE_VIM_LEFT:
+    intendedmove[FLAG_MOVE_LEFT] = true;
+    return false;
+  case CODE_VIM_DOWN:
+    intendedmove[FLAG_MOVE_DOWN] = true;
+    return false;
+  case CODE_VIM_RIGHT:
+    intendedmove[FLAG_MOVE_RIGHT] = true;
+    return false;
+  }
+  return true;
+}
+
+bool check_input_wasd(char c, intendedmove_t &intendedmove) {
+  using namespace Keypress::Code;
+  switch (toupper(c)) {
+  case CODE_WASD_UP:
+    intendedmove[FLAG_MOVE_UP] = true;
+    return false;
+  case CODE_WASD_LEFT:
+    intendedmove[FLAG_MOVE_LEFT] = true;
+    return false;
+  case CODE_WASD_DOWN:
+    intendedmove[FLAG_MOVE_DOWN] = true;
+    return false;
+  case CODE_WASD_RIGHT:
+    intendedmove[FLAG_MOVE_RIGHT] = true;
+    return false;
+  }
+  return true;
+}
+} // namespace Input
+} // namespace Game

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -308,14 +308,14 @@ void drawScoreBoard(std::ostream &out_stream) {
   out_stream << outer_border_padding << bottom_board << "\n \n";
 }
 
-void drawBoard() {
+void drawBoard(std::ostream &os) {
   clearScreen();
   drawAscii();
-  drawScoreBoard(std::cout);
-  std::cout << gamePlayBoard;
+  drawScoreBoard(os);
+  os << gamePlayBoard;
 }
 
-void drawInputError() {
+void drawInputError(std::ostream &os) {
   constexpr auto invalid_prompt_text = "Invalid input. Please try again.";
   constexpr auto sp = "  ";
   std::ostringstream str_os;
@@ -326,10 +326,10 @@ void drawInputError() {
     str_os << invalid_prompt_richtext.str();
     gamestatus[FLAG_INPUT_ERROR] = false;
   }
-  std::cout << str_os.str();
+  os << str_os.str();
 }
 
-void drawInputControls() {
+void drawInputControls(std::ostream &os) {
   constexpr auto sp = "  ";
   const auto input_commands_list_text = {
       "W or K or ↑ => Up", "A or H or ← => Left", "S or J or ↓ => Down",
@@ -351,7 +351,7 @@ void drawInputControls() {
     str_os << sp << txt << "\n";
   }
   if (!gamestatus[FLAG_QUESTION_STAY_OR_QUIT]) {
-    std::cout << str_os.str();
+    os << str_os.str();
   }
 }
 
@@ -469,7 +469,7 @@ void decideMove(Directions d) {
   }
 }
 
-void statistics() {
+void statistics(std::ostream &os) {
   constexpr auto stats_title_text = "STATISTICS";
   constexpr auto divider_text = "──────────";
   const auto stats_attributes_text = {
@@ -498,7 +498,7 @@ void statistics() {
   std::for_each(std::begin(stats_attributes_text),
                 std::end(stats_attributes_text), populate_stats_info);
 
-  std::cout << stats_richtext.str();
+  os << stats_richtext.str();
 }
 
 void saveStats() {
@@ -521,7 +521,6 @@ void saveStats() {
 
 void saveScore() {
   Scoreboard::Score tempscore{};
-  drawPromptForPlayerName(std::cout);
   auto name = receive_input_player_name(std::cin);
 
   tempscore.name = name;
@@ -531,7 +530,6 @@ void saveScore() {
   tempscore.largestTile = gamePlayBoard.largestTile;
   tempscore.duration = duration;
   Scoreboard::saveToFileScore("../data/scores.txt", tempscore);
-  drawMessageScoreSaved(std::cout);
 }
 
 void saveState() {
@@ -545,7 +543,7 @@ void saveState() {
   stats.close();
 }
 
-void drawEndScreen() {
+void drawEndScreen(std::ostream &os) {
   constexpr auto win_game_text = "You win! Congratulations!";
   constexpr auto lose_game_text = "Game over! You lose.";
   constexpr auto endless_mode_text =
@@ -574,10 +572,10 @@ void drawEndScreen() {
   } else {
     str_os << endless_mode_richtext.str();
   }
-  std::cout << str_os.str();
+  os << str_os.str();
 }
 
-void drawGameState() {
+void drawGameState(std::ostream &os) {
   constexpr auto state_saved_text =
       "The game has been saved. Feel free to take a break.";
   constexpr auto sp = "  ";
@@ -591,10 +589,10 @@ void drawGameState() {
     str_os << state_saved_richtext.str();
     gamestatus[FLAG_SAVED_GAME] = false;
   }
-  std::cout << str_os.str();
+  os << str_os.str();
 }
 
-void drawEndOfGamePrompt() {
+void drawEndOfGamePrompt(std::ostream &os) {
   constexpr auto win_but_what_next =
       "You Won! Continue playing current game? [y/n]";
   constexpr auto sp = "  ";
@@ -606,16 +604,16 @@ void drawEndOfGamePrompt() {
 
   if (gamestatus[FLAG_QUESTION_STAY_OR_QUIT]) {
     str_os << win_richtext.str();
-    std::cout << str_os.str();
+    os << str_os.str();
   }
 }
 
-void drawGraphics() {
-  drawBoard();
-  drawGameState();
-  drawEndOfGamePrompt();
-  drawInputControls();
-  drawInputError();
+void drawGraphics(std::ostream &os) {
+  drawBoard(os);
+  drawGameState(os);
+  drawEndOfGamePrompt(os);
+  drawInputControls(os);
+  drawInputError(os);
 }
 
 void process_gamelogic() {
@@ -696,7 +694,7 @@ bool process_gameStatus() {
 
 bool soloGameLoop() {
   process_gamelogic();
-  drawGraphics();
+  drawGraphics(std::cout);
   input();
   process_intendedMove();
   const auto loop_again = process_gameStatus();
@@ -716,15 +714,17 @@ void playGame(ContinueStatus cont) {
   std::chrono::duration<double> elapsed = finishTime - startTime;
   duration = elapsed.count();
 
-  drawBoard();
-  drawEndScreen();
+  drawBoard(std::cout);
+  drawEndScreen(std::cout);
 
   if (gamePlayBoard.getPlaySize() == COMPETITION_GAME_BOARD_PLAY_SIZE &&
       cont == ContinueStatus::STATUS_END_GAME) {
-    statistics();
+    statistics(std::cout);
     saveStats();
     newline(2);
+    drawPromptForPlayerName(std::cout);
     saveScore();
+    drawMessageScoreSaved(std::cout);
   }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -57,6 +57,9 @@ enum {
 } // namespace Code
 } // namespace Keypress
 
+Game::gamestatus_t gamestatus{};
+Game::intendedmove_t intendedmove{};
+
 ull bestScore;
 double duration;
 GameBoard gamePlayBoard;
@@ -220,7 +223,7 @@ bool Game::initialiseContinueBoardArray() {
           load_game_stats_from_file(game_stats_data_filename));
 }
 
-void Game::drawBoard() const {
+void Game::drawBoard() {
 
   clearScreen();
   drawAscii();
@@ -228,7 +231,7 @@ void Game::drawBoard() const {
   std::cout << gamePlayBoard;
 }
 
-void Game::drawScoreBoard(std::ostream &out_stream) const {
+void Game::drawScoreBoard(std::ostream &out_stream) {
   constexpr auto score_text_label = "SCORE:";
   constexpr auto bestscore_text_label = "BEST SCORE:";
   constexpr auto moves_text_label = "MOVES:";
@@ -445,7 +448,7 @@ void Game::decideMove(Directions d) {
   }
 }
 
-void Game::statistics() const {
+void Game::statistics() {
   constexpr auto stats_title_text = "STATISTICS";
   constexpr auto divider_text = "──────────";
   const auto stats_attributes_text = {
@@ -477,7 +480,7 @@ void Game::statistics() const {
   std::cout << stats_richtext.str();
 }
 
-void Game::saveStats() const {
+void Game::saveStats() {
   using namespace Statistics;
   total_game_stats_t stats;
   // Need some sort of stats data values only.
@@ -495,7 +498,7 @@ void Game::saveStats() const {
   saveToFileStatistics("../data/statistics.txt", stats);
 }
 
-void Game::saveScore() const {
+void Game::saveScore() {
   Scoreboard::Score tempscore{};
   drawPromptForPlayerName(std::cout);
   auto name = receive_input_player_name(std::cin);
@@ -510,7 +513,7 @@ void Game::saveScore() const {
   drawMessageScoreSaved(std::cout);
 }
 
-void Game::saveState() const {
+void Game::saveState() {
   std::remove("../data/previousGame");
   std::remove("../data/previousGameStats");
   std::fstream stats("../data/previousGameStats", std::ios_base::app);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -41,15 +41,17 @@ std::string receive_input_player_name(std::istream &is) {
   return name;
 }
 
-void load_game_best_score() {
+ull load_game_best_score() {
   using namespace Statistics;
   total_game_stats_t stats;
   bool stats_file_loaded{};
+  ull tempscore{0};
   std::tie(stats_file_loaded, stats) =
       loadFromFileStatistics("../data/statistics.txt");
   if (stats_file_loaded) {
-    bestScore = stats.bestScore;
+    tempscore = stats.bestScore;
   }
+  return tempscore;
 }
 
 load_gameboard_status_t initialiseContinueBoardArray() {
@@ -406,7 +408,7 @@ void endlessGameLoop() {
 enum class PlayGameFlag { BrandNewGame, ContinuePreviousGame };
 
 void playGame(PlayGameFlag cont, ull userInput_PlaySize = 1) {
-  load_game_best_score();
+  bestScore = load_game_best_score();
   if (cont == PlayGameFlag::BrandNewGame) {
     gamePlayBoard = GameBoard(userInput_PlaySize);
     gamePlayBoard.addTile();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,5 +1,7 @@
 #include "game.hpp"
+#include "gameboard.hpp"
 #include "menu.hpp"
+#include "point2d.hpp"
 #include "scores.hpp"
 #include "statistics.hpp"
 #include <algorithm>
@@ -54,6 +56,12 @@ enum {
 
 } // namespace Code
 } // namespace Keypress
+
+ull bestScore;
+double duration;
+GameBoard gamePlayBoard;
+RandInt randInt;
+bool noSave;
 
 int GetLines(std::string filename) {
   std::ifstream stateFile(filename);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5,6 +5,7 @@
 #include "global.hpp"
 #include "loadresource.hpp"
 #include "point2d.hpp"
+#include "saveresource.hpp"
 #include "scores.hpp"
 #include "statistics.hpp"
 #include <algorithm>
@@ -294,34 +295,16 @@ void saveScore() {
   Scoreboard::saveToFileScore("../data/scores.txt", tempscore);
 }
 
-bool generateFilefromPreviousGameStatisticsData(std::ostream &os) {
-  os << gamePlayBoard.score << ":" << gamePlayBoard.MoveCount();
-  return true;
-}
-
-void saveToFilePreviousGameStatisticsData(std::string filename) {
-  std::ofstream stats(filename, std::ios_base::app);
-  generateFilefromPreviousGameStatisticsData(stats);
-}
-
-bool generateFilefromPreviousGameStateData(std::ostream &os) {
-  os << gamePlayBoard.printState();
-  return true;
-}
-
-void saveToFilePreviousGameStateData(std::string filename) {
-  std::ofstream stateFile(filename, std::ios_base::app);
-  generateFilefromPreviousGameStateData(stateFile);
-}
-
 void saveGamePlayState() {
+  using namespace Game::Saver;
   // Currently two datafiles for now.
   // Will be merged into one datafile in a future PR.
   std::remove("../data/previousGame");
   std::remove("../data/previousGameStats");
 
-  saveToFilePreviousGameStateData("../data/previousGame");
-  saveToFilePreviousGameStatisticsData("../data/previousGameStats");
+  saveToFilePreviousGameStateData("../data/previousGame", gamePlayBoard);
+  saveToFilePreviousGameStatisticsData("../data/previousGameStats",
+                                       gamePlayBoard);
 }
 
 void drawEndScreen(std::ostream &os) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <sstream>
 
+namespace Game {
 namespace {
 enum Directions { UP, DOWN, RIGHT, LEFT };
 
@@ -53,7 +54,7 @@ ull load_game_best_score() {
 }
 
 load_gameboard_status_t initialiseContinueBoardArray() {
-  using namespace Game::Loader;
+  using namespace Loader;
   constexpr auto gameboard_data_filename = "../data/previousGame";
   constexpr auto game_stats_data_filename = "../data/previousGameStats";
   auto loaded_gameboard{false};
@@ -144,10 +145,10 @@ void drawBoard(std::ostream &os) {
 void drawInputControls(std::ostream &os, gamestatus_t gamestatus) {
   const auto InputControlLists = [&gamestatus] {
     std::ostringstream str_os;
-    DrawAlways(str_os, Game::Graphics::InputCommandListPrompt);
+    DrawAlways(str_os, Graphics::InputCommandListPrompt);
     DrawOnlyWhen(str_os, gamestatus[FLAG_ENDLESS_MODE],
-                 Game::Graphics::EndlessModeCommandListPrompt);
-    DrawAlways(str_os, Game::Graphics::InputCommandListFooterPrompt);
+                 Graphics::EndlessModeCommandListPrompt);
+    DrawAlways(str_os, Graphics::InputCommandListFooterPrompt);
     return str_os.str();
   };
   // When game is paused to ask a question, hide regular inut prompts..
@@ -176,18 +177,18 @@ gamestatus_t process_gamelogic(gamestatus_t gamestatus) {
 gamestatus_t drawGraphics(std::ostream &os, gamestatus_t gamestatus) {
   drawBoard(os);
   DrawAsOneTimeFlag(os, gamestatus[FLAG_SAVED_GAME],
-                    Game::Graphics::GameStateNowSavedPrompt);
+                    Graphics::GameStateNowSavedPrompt);
   DrawOnlyWhen(os, gamestatus[FLAG_QUESTION_STAY_OR_QUIT],
-               Game::Graphics::QuestionEndOfWinningGamePrompt);
+               Graphics::QuestionEndOfWinningGamePrompt);
   drawInputControls(os, gamestatus);
   DrawAsOneTimeFlag(os, gamestatus[FLAG_INPUT_ERROR],
-                    Game::Graphics::InvalidInputGameBoardErrorPrompt);
+                    Graphics::InvalidInputGameBoardErrorPrompt);
   return gamestatus;
 }
 
 using wrapper_bool_gamestatus_t = std::tuple<bool, gamestatus_t>;
 wrapper_bool_gamestatus_t check_input_other(char c, gamestatus_t gamestatus) {
-  using namespace Game::Input::Keypress::Code;
+  using namespace Input::Keypress::Code;
   auto is_invalid_keycode{true};
   switch (toupper(c)) {
   case CODE_HOTKEY_ACTION_SAVE:
@@ -205,9 +206,9 @@ wrapper_bool_gamestatus_t check_input_other(char c, gamestatus_t gamestatus) {
   return std::make_tuple(is_invalid_keycode, gamestatus);
 }
 
-gamestatus_t receive_agent_input(Game::Input::intendedmove_t &intendedmove,
+gamestatus_t receive_agent_input(Input::intendedmove_t &intendedmove,
                                  gamestatus_t gamestatus) {
-  using namespace Game::Input;
+  using namespace Input;
   const bool game_still_in_play =
       !gamestatus[FLAG_END_GAME] && !gamestatus[FLAG_WIN];
   if (game_still_in_play) {
@@ -248,8 +249,8 @@ void decideMove(Directions d) {
   }
 }
 
-bool process_agent_input(Game::Input::intendedmove_t &intendedmove) {
-  using namespace Game::Input;
+bool process_agent_input(Input::intendedmove_t &intendedmove) {
+  using namespace Input;
   if (intendedmove[FLAG_MOVE_LEFT]) {
     decideMove(LEFT);
   }
@@ -268,7 +269,7 @@ bool process_agent_input(Game::Input::intendedmove_t &intendedmove) {
 }
 
 bool check_input_check_to_end_game(char c) {
-  using namespace Game::Input::Keypress::Code;
+  using namespace Input::Keypress::Code;
   switch (std::toupper(c)) {
   case CODE_HOTKEY_CHOICE_NO:
     return true;
@@ -286,7 +287,7 @@ bool continue_playing_game(std::istream &in_os) {
 }
 
 void saveGamePlayState() {
-  using namespace Game::Saver;
+  using namespace Saver;
   // Currently two datafiles for now.
   // Will be merged into one datafile in a future PR.
   std::remove("../data/previousGame");
@@ -321,7 +322,7 @@ wrapper_bool_gamestatus_t process_gameStatus(gamestatus_t gamestatus) {
 }
 
 wrapper_bool_gamestatus_t soloGameLoop(gamestatus_t gamestatus) {
-  using namespace Game::Input;
+  using namespace Input;
   intendedmove_t player_intendedmove{};
   gamestatus = process_gamelogic(gamestatus);
   gamestatus = drawGraphics(std::cout, gamestatus);
@@ -334,15 +335,14 @@ wrapper_bool_gamestatus_t soloGameLoop(gamestatus_t gamestatus) {
 void drawEndScreen(std::ostream &os, gamestatus_t gamestatus) {
   const auto standardWinLosePrompt = [&gamestatus] {
     std::ostringstream str_os;
-    DrawOnlyWhen(str_os, gamestatus[FLAG_WIN], Game::Graphics::YouWinPrompt);
+    DrawOnlyWhen(str_os, gamestatus[FLAG_WIN], Graphics::YouWinPrompt);
     // else..
-    DrawOnlyWhen(str_os, !gamestatus[FLAG_WIN], Game::Graphics::GameOverPrompt);
+    DrawOnlyWhen(str_os, !gamestatus[FLAG_WIN], Graphics::GameOverPrompt);
     return str_os.str();
   };
   DrawOnlyWhen(os, !gamestatus[FLAG_ENDLESS_MODE], standardWinLosePrompt);
   // else..
-  DrawOnlyWhen(os, gamestatus[FLAG_ENDLESS_MODE],
-               Game::Graphics::EndOfEndlessPrompt);
+  DrawOnlyWhen(os, gamestatus[FLAG_ENDLESS_MODE], Graphics::EndOfEndlessPrompt);
 }
 
 void endlessGameLoop() {
@@ -422,12 +422,12 @@ void DoPostGameSaveStuff(double duration) {
     drawEndGameStatistics(std::cout, finalscore);
     saveEndGameStats(finalscore);
 
-    DrawAlways(std::cout, Game::Graphics::AskForPlayerNamePrompt);
+    DrawAlways(std::cout, Graphics::AskForPlayerNamePrompt);
     const auto name = receive_input_player_name(std::cin);
     finalscore.name = name;
 
     saveScore(finalscore);
-    DrawAlways(std::cout, Game::Graphics::MessageScoreSavedPrompt);
+    DrawAlways(std::cout, Graphics::MessageScoreSavedPrompt);
   }
 }
 
@@ -468,9 +468,8 @@ ull askWhatIsBoardSize(std::ostream &os) {
     clearScreen();
     drawAscii();
     // Prints only if "invalidInputValue" is true
-    DrawOnlyWhen(str_os, invalidInputValue,
-                 Game::Graphics::BoardSizeErrorPrompt);
-    DrawAlways(str_os, Game::Graphics::BoardInputPrompt);
+    DrawOnlyWhen(str_os, invalidInputValue, Graphics::BoardSizeErrorPrompt);
+    DrawAlways(str_os, Graphics::BoardInputPrompt);
     return str_os.str();
   };
 
@@ -489,8 +488,7 @@ void SetUpNewGame(NewGameFlag ns = NewGameFlag::NewGameFlagNull) {
   auto noSave = (ns == NewGameFlag::NoPreviousSaveAvailable) ? true : false;
   // Prints only if "noSave" is true
   // Consumes "noSave" flag (turns flag to false/off)
-  DrawAsOneTimeFlag(std::cout, noSave,
-                    Game::Graphics::GameBoardNoSaveErrorPrompt);
+  DrawAsOneTimeFlag(std::cout, noSave, Graphics::GameBoardNoSaveErrorPrompt);
   ull userInput_PlaySize = askWhatIsBoardSize(std::cout);
   playGame(PlayGameFlag::BrandNewGame, userInput_PlaySize);
 }
@@ -509,10 +507,12 @@ void ContinueOldGame() {
 
 } // namespace
 
-void Game::startGame() {
+void startGame() {
   SetUpNewGame();
 }
 
-void Game::continueGame() {
+void continueGame() {
   ContinueOldGame();
 }
+
+} // namespace Game

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -470,7 +470,7 @@ void drawEndGameStatistics(std::ostream &os) {
   os << stats_richtext.str();
 }
 
-void saveStats() {
+void saveEndGameStats() {
   using namespace Statistics;
   total_game_stats_t stats;
   // Need some sort of stats data values only.
@@ -485,7 +485,7 @@ void saveStats() {
   stats.totalMoveCount += gamePlayBoard.MoveCount();
   stats.totalDuration += duration;
 
-  saveToFileStatistics("../data/statistics.txt", stats);
+  saveToFileEndGameStatistics("../data/statistics.txt", stats);
 }
 
 void saveScore() {
@@ -501,15 +501,34 @@ void saveScore() {
   Scoreboard::saveToFileScore("../data/scores.txt", tempscore);
 }
 
-void saveState() {
+bool generateFilefromPreviousGameStatisticsData(std::ostream &os) {
+  os << gamePlayBoard.score << ":" << gamePlayBoard.MoveCount();
+  return true;
+}
+
+void saveToFilePreviousGameStatisticsData(std::string filename) {
+  std::ofstream stats(filename, std::ios_base::app);
+  generateFilefromPreviousGameStatisticsData(stats);
+}
+
+bool generateFilefromPreviousGameStateData(std::ostream &os) {
+  os << gamePlayBoard.printState();
+  return true;
+}
+
+void saveToFilePreviousGameStateData(std::string filename) {
+  std::ofstream stateFile(filename, std::ios_base::app);
+  generateFilefromPreviousGameStateData(stateFile);
+}
+
+void saveGamePlayState() {
+  // Currently two datafiles for now.
+  // Will be merged into one datafile in a future PR.
   std::remove("../data/previousGame");
   std::remove("../data/previousGameStats");
-  std::fstream stats("../data/previousGameStats", std::ios_base::app);
-  std::fstream stateFile("../data/previousGame", std::ios_base::app);
-  stateFile << gamePlayBoard.printState();
-  stateFile.close();
-  stats << gamePlayBoard.score << ":" << gamePlayBoard.MoveCount();
-  stats.close();
+
+  saveToFilePreviousGameStateData("../data/previousGame");
+  saveToFilePreviousGameStatisticsData("../data/previousGameStats");
 }
 
 void drawEndScreen(std::ostream &os) {
@@ -608,7 +627,7 @@ bool process_gameStatus() {
     return false;
   }
   if (gamestatus[FLAG_SAVED_GAME]) {
-    saveState();
+    saveGamePlayState();
   }
   return true;
 }
@@ -641,7 +660,7 @@ void playGame(ContinueStatus cont) {
   if (gamePlayBoard.getPlaySize() == COMPETITION_GAME_BOARD_PLAY_SIZE &&
       cont == ContinueStatus::STATUS_END_GAME) {
     drawEndGameStatistics(std::cout);
-    saveStats();
+    saveEndGameStats();
     newline(2);
     DrawAlways(std::cout, Game::Graphics::AskForPlayerNamePrompt);
     saveScore();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -175,15 +175,6 @@ void load_game_best_score() {
 
 } // namespace
 
-Color::Modifier Tile::tileColor(ull value) {
-  std::vector<Color::Modifier> colors{red, yellow, magenta, blue, cyan, yellow,
-                                      red, yellow, magenta, blue, green};
-  int log = log2(value);
-  int index = log < 12 ? log - 1 : 10;
-
-  return colors[index];
-}
-
 bool Game::get_and_process_game_stats_string_data(std::istream &stats_file) {
   if (stats_file) {
     for (std::string tempLine; std::getline(stats_file, tempLine);) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -93,7 +93,6 @@ ull bestScore;
 double duration;
 GameBoard gamePlayBoard;
 RandInt randInt;
-bool noSave;
 
 int GetLines(std::string filename) {
   std::ifstream stateFile(filename);
@@ -788,11 +787,14 @@ ull Receive_Input_Playsize(std::istream &is) {
   return userInput_PlaySize;
 }
 
-ull askWhatIsBoardSize(std::ostream &os) {
+enum class NewGameFlag { NewGameFlagNull, NoPreviousSaveAvailable };
+
+ull askWhatIsBoardSize(std::ostream &os, NewGameFlag ns) {
+  bool noSave = (ns == NewGameFlag::NoPreviousSaveAvailable) ? true : false;
   bool invalidInputValue = false;
   ull userInput_PlaySize{0};
 
-  const auto DrawGraphics = [&invalidInputValue](std::ostream &os) {
+  const auto DrawGraphics = [&invalidInputValue, &noSave](std::ostream &os) {
     clearScreen();
     drawAscii();
     // Prints only if "invalidInputValue" is true
@@ -812,20 +814,23 @@ ull askWhatIsBoardSize(std::ostream &os) {
   return userInput_PlaySize;
 }
 
-} // namespace
-
-void Game::startGame() {
-  ull userInput_PlaySize = askWhatIsBoardSize(std::cout);
+void SetUpNewGame(NewGameFlag ns = NewGameFlag::NewGameFlagNull) {
+  ull userInput_PlaySize = askWhatIsBoardSize(std::cout, ns);
   gamePlayBoard = GameBoard(userInput_PlaySize);
   gamePlayBoard.addTile();
   playGame(ContinueStatus::STATUS_END_GAME);
+}
+
+} // namespace
+
+void Game::startGame() {
+  SetUpNewGame();
 }
 
 void Game::continueGame() {
   if (initialiseContinueBoardArray()) {
     playGame(ContinueStatus::STATUS_CONTINUE);
   } else {
-    noSave = true;
-    startGame();
+    SetUpNewGame(NewGameFlag::NoPreviousSaveAvailable);
   }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -162,6 +162,17 @@ std::string receive_input_player_name(std::istream &is) {
   return name;
 }
 
+void load_game_best_score() {
+  using namespace Statistics;
+  total_game_stats_t stats;
+  bool stats_file_loaded{};
+  std::tie(stats_file_loaded, stats) =
+      loadFromFileStatistics("../data/statistics.txt");
+  if (stats_file_loaded) {
+    bestScore = stats.bestScore;
+  }
+}
+
 } // namespace
 
 Color::Modifier Tile::tileColor(ull value) {
@@ -683,6 +694,7 @@ void Game::endlessGameLoop() {
 }
 
 void Game::playGame(ContinueStatus cont) {
+  load_game_best_score();
   auto startTime = std::chrono::high_resolution_clock::now();
   endlessGameLoop();
   auto finishTime = std::chrono::high_resolution_clock::now();
@@ -754,33 +766,13 @@ ull Game::setBoardSize() {
 }
 
 void Game::startGame() {
-  using namespace Statistics;
-  total_game_stats_t stats;
-  bool stats_file_loaded{};
-  std::tie(stats_file_loaded, stats) =
-      loadFromFileStatistics("../data/statistics.txt");
-  if (stats_file_loaded) {
-    bestScore = stats.bestScore;
-  }
-
   ull userInput_PlaySize = setBoardSize();
-
   gamePlayBoard = GameBoard(userInput_PlaySize);
   gamePlayBoard.addTile();
-
   playGame(ContinueStatus::STATUS_END_GAME);
 }
 
 void Game::continueGame() {
-  using namespace Statistics;
-  total_game_stats_t stats;
-  bool stats_file_loaded{};
-  std::tie(stats_file_loaded, stats) =
-      loadFromFileStatistics("../data/statistics.txt");
-  if (stats_file_loaded) {
-    bestScore = stats.bestScore;
-  }
-
   if (initialiseContinueBoardArray()) {
     playGame(ContinueStatus::STATUS_CONTINUE);
   } else {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -34,27 +34,6 @@ gamestatus_t gamestatus{};
 ull bestScore;
 double duration;
 GameBoard gamePlayBoard;
-RandInt randInt;
-
-template<typename T>
-void DrawAlways(std::ostream &os, T f) {
-  os << f();
-}
-
-template<typename T>
-void DrawOnlyWhen(std::ostream &os, bool trigger, T f) {
-  if (trigger) {
-    DrawAlways(os, f);
-  }
-}
-
-template<typename T>
-void DrawAsOneTimeFlag(std::ostream &os, bool &trigger, T f) {
-  if (trigger) {
-    DrawAlways(os, f);
-    trigger = !trigger;
-  }
-}
 
 std::string receive_input_player_name(std::istream &is) {
   std::string name;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -180,10 +180,8 @@ void drawPromptForPlayerName(std::ostream &os) {
   constexpr auto score_prompt_text =
       "Please enter your name to save this score: ";
   constexpr auto sp = "  ";
-
   std::ostringstream score_prompt_richtext;
   score_prompt_richtext << bold_on << sp << score_prompt_text << bold_off;
-
   os << score_prompt_richtext.str();
 }
 
@@ -249,7 +247,7 @@ bool initialiseContinueBoardArray() {
           load_game_stats_from_file(game_stats_data_filename));
 }
 
-void drawScoreBoard(std::ostream &out_stream) {
+void drawScoreBoard(std::ostream &os) {
   constexpr auto score_text_label = "SCORE:";
   constexpr auto bestscore_text_label = "BEST SCORE:";
   constexpr auto moves_text_label = "MOVES:";
@@ -277,38 +275,36 @@ void drawScoreBoard(std::ostream &out_stream) {
       std::string(UI_BORDER_INNER_PADDING, border_padding_char);
   const auto inner_padding_length =
       UI_SCOREBOARD_SIZE - (std::string{inner_border_padding}.length() * 2);
-  out_stream << outer_border_padding << top_board << "\n";
-  out_stream << outer_border_padding << vertical_border_pattern
-             << inner_border_padding << bold_on << score_text_label << bold_off
-             << std::string(inner_padding_length -
-                                std::string{score_text_label}.length() -
-                                std::to_string(gamePlayBoard.score).length(),
-                            border_padding_char)
-             << gamePlayBoard.score << inner_border_padding
-             << vertical_border_pattern << "\n";
+  os << outer_border_padding << top_board << "\n";
+  os << outer_border_padding << vertical_border_pattern << inner_border_padding
+     << bold_on << score_text_label << bold_off
+     << std::string(inner_padding_length -
+                        std::string{score_text_label}.length() -
+                        std::to_string(gamePlayBoard.score).length(),
+                    border_padding_char)
+     << gamePlayBoard.score << inner_border_padding << vertical_border_pattern
+     << "\n";
   if (gamePlayBoard.getPlaySize() == COMPETITION_GAME_BOARD_PLAY_SIZE) {
     const auto tempBestScore =
         (bestScore < gamePlayBoard.score ? gamePlayBoard.score : bestScore);
-    out_stream << outer_border_padding << vertical_border_pattern
-               << inner_border_padding << bold_on << bestscore_text_label
-               << bold_off
-               << std::string(inner_padding_length -
-                                  std::string{bestscore_text_label}.length() -
-                                  std::to_string(tempBestScore).length(),
-                              border_padding_char)
-               << tempBestScore << inner_border_padding
-               << vertical_border_pattern << "\n";
+    os << outer_border_padding << vertical_border_pattern
+       << inner_border_padding << bold_on << bestscore_text_label << bold_off
+       << std::string(inner_padding_length -
+                          std::string{bestscore_text_label}.length() -
+                          std::to_string(tempBestScore).length(),
+                      border_padding_char)
+       << tempBestScore << inner_border_padding << vertical_border_pattern
+       << "\n";
   }
-  out_stream << outer_border_padding << vertical_border_pattern
-             << inner_border_padding << bold_on << moves_text_label << bold_off
-             << std::string(
-                    inner_padding_length -
+  os << outer_border_padding << vertical_border_pattern << inner_border_padding
+     << bold_on << moves_text_label << bold_off
+     << std::string(inner_padding_length -
                         std::string{moves_text_label}.length() -
                         std::to_string(gamePlayBoard.MoveCount()).length(),
                     border_padding_char)
-             << gamePlayBoard.MoveCount() << inner_border_padding
-             << vertical_border_pattern << "\n";
-  out_stream << outer_border_padding << bottom_board << "\n \n";
+     << gamePlayBoard.MoveCount() << inner_border_padding
+     << vertical_border_pattern << "\n";
+  os << outer_border_padding << bottom_board << "\n \n";
 }
 
 void drawBoard(std::ostream &os) {
@@ -319,17 +315,15 @@ void drawBoard(std::ostream &os) {
 }
 
 void drawInputError(std::ostream &os) {
-  constexpr auto invalid_prompt_text = "Invalid input. Please try again.";
-  constexpr auto sp = "  ";
-  std::ostringstream str_os;
-  std::ostringstream invalid_prompt_richtext;
-  invalid_prompt_richtext << red << sp << invalid_prompt_text << def << "\n\n";
-
   if (gamestatus[FLAG_INPUT_ERROR]) {
-    str_os << invalid_prompt_richtext.str();
+    constexpr auto invalid_prompt_text = "Invalid input. Please try again.";
+    constexpr auto sp = "  ";
+    std::ostringstream invalid_prompt_richtext;
+    invalid_prompt_richtext << red << sp << invalid_prompt_text << def
+                            << "\n\n";
+    os << invalid_prompt_richtext.str();
     gamestatus[FLAG_INPUT_ERROR] = false;
   }
-  os << str_os.str();
 }
 
 void drawInputControls(std::ostream &os) {
@@ -587,35 +581,27 @@ void drawEndScreen(std::ostream &os) {
 }
 
 void drawGameState(std::ostream &os) {
-  constexpr auto state_saved_text =
-      "The game has been saved. Feel free to take a break.";
-  constexpr auto sp = "  ";
-
-  std::ostringstream str_os;
-  std::ostringstream state_saved_richtext;
-  state_saved_richtext << green << bold_on << sp << state_saved_text << def
-                       << bold_off << "\n\n";
-
   if (gamestatus[FLAG_SAVED_GAME]) {
-    str_os << state_saved_richtext.str();
+    constexpr auto state_saved_text =
+        "The game has been saved. Feel free to take a break.";
+    constexpr auto sp = "  ";
+    std::ostringstream state_saved_richtext;
+    state_saved_richtext << green << bold_on << sp << state_saved_text << def
+                         << bold_off << "\n\n";
+    os << state_saved_richtext.str();
     gamestatus[FLAG_SAVED_GAME] = false;
   }
-  os << str_os.str();
 }
 
 void drawEndOfGamePrompt(std::ostream &os) {
-  constexpr auto win_but_what_next =
-      "You Won! Continue playing current game? [y/n]";
-  constexpr auto sp = "  ";
-
-  std::ostringstream str_os;
-  std::ostringstream win_richtext;
-  win_richtext << green << bold_on << sp << win_but_what_next << def << bold_off
-               << ": ";
-
   if (gamestatus[FLAG_QUESTION_STAY_OR_QUIT]) {
-    str_os << win_richtext.str();
-    os << str_os.str();
+    constexpr auto win_but_what_next =
+        "You Won! Continue playing current game? [y/n]";
+    constexpr auto sp = "  ";
+    std::ostringstream win_richtext;
+    win_richtext << green << bold_on << sp << win_but_what_next << def
+                 << bold_off << ": ";
+    os << win_richtext.str();
   }
 }
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -44,12 +44,6 @@ void wait_for_any_letter_input(std::istream &is) {
   is >> c;
 }
 
-void newline(int n) {
-  for (int i = 0; i < n; i++) {
-    std::cout << "\n";
-  }
-};
-
 void clearScreen() {
   system("clear");
 };

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -5,7 +5,7 @@
 
 #ifdef _WIN32
 
-void getInput(char &c) {
+void getKeypressDownInput(char &c) {
   std::cin >> c;
 }
 
@@ -33,7 +33,7 @@ char getch() {
   return (buf);
 }
 
-void getInput(char &c) {
+void getKeypressDownInput(char &c) {
   c = getch();
 }
 

--- a/src/headers/game-graphics.hpp
+++ b/src/headers/game-graphics.hpp
@@ -1,0 +1,31 @@
+#ifndef GAMEGRAPHICS_H
+#define GAMEGRAPHICS_H
+
+#include <string>
+
+enum GameBoardDimensions {
+  MIN_GAME_BOARD_PLAY_SIZE = 3,
+  MAX_GAME_BOARD_PLAY_SIZE = 10
+};
+enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
+
+namespace Game {
+namespace Graphics {
+std::string MessageScoreSavedPrompt();
+std::string AskForPlayerNamePrompt();
+std::string BoardInputPrompt();
+std::string YouWinPrompt();
+std::string GameOverPrompt();
+std::string EndOfEndlessPrompt();
+std::string InvalidInputGameBoardErrorPrompt();
+std::string QuestionEndOfWinningGamePrompt();
+std::string GameStateNowSavedPrompt();
+std::string GameBoardNoSaveErrorPrompt();
+std::string BoardSizeErrorPrompt();
+std::string InputCommandListPrompt();
+std::string EndlessModeCommandListPrompt();
+std::string InputCommandListFooterPrompt();
+} // namespace Graphics
+} // namespace Game
+
+#endif

--- a/src/headers/game-input.hpp
+++ b/src/headers/game-input.hpp
@@ -1,0 +1,70 @@
+#ifndef GAMEINPUT_H
+#define GAMEINPUT_H
+
+#include <array>
+
+namespace Game {
+namespace Input {
+
+namespace Keypress {
+namespace Code {
+
+enum { CODE_ESC = 27, CODE_LSQUAREBRACKET = '[' };
+
+// Hotkey bindings:
+// Style: ANSI (Arrow Keys)
+enum {
+  CODE_ANSI_TRIGGER_1 = CODE_ESC,
+  CODE_ANSI_TRIGGER_2 = CODE_LSQUAREBRACKET
+};
+enum {
+  CODE_ANSI_UP = 'A',
+  CODE_ANSI_DOWN = 'B',
+  CODE_ANSI_LEFT = 'D',
+  CODE_ANSI_RIGHT = 'C'
+};
+
+// Style: WASD
+enum {
+  CODE_WASD_UP = 'W',
+  CODE_WASD_DOWN = 'S',
+  CODE_WASD_LEFT = 'A',
+  CODE_WASD_RIGHT = 'D'
+};
+
+// Style: Vim
+enum {
+  CODE_VIM_UP = 'K',
+  CODE_VIM_DOWN = 'J',
+  CODE_VIM_LEFT = 'H',
+  CODE_VIM_RIGHT = 'L'
+};
+
+enum {
+  CODE_HOTKEY_ACTION_SAVE = 'Z',
+  CODE_HOTKEY_ALTERNATE_ACTION_SAVE = 'P',
+  CODE_HOTKEY_QUIT_ENDLESS_MODE = 'X',
+  CODE_HOTKEY_CHOICE_NO = 'N',
+  CODE_HOTKEY_CHOICE_YES = 'Y'
+};
+
+} // namespace Code
+} // namespace Keypress
+
+enum IntendedMoveFlag {
+  FLAG_MOVE_LEFT,
+  FLAG_MOVE_RIGHT,
+  FLAG_MOVE_UP,
+  FLAG_MOVE_DOWN,
+  MAX_NO_INTENDED_MOVE_FLAGS
+};
+using intendedmove_t = std::array<bool, MAX_NO_INTENDED_MOVE_FLAGS>;
+
+bool check_input_ansi(char c, intendedmove_t &intendedmove);
+bool check_input_vim(char c, intendedmove_t &intendedmove);
+bool check_input_wasd(char c, intendedmove_t &intendedmove);
+
+} // namespace Input
+} // namespace Game
+
+#endif

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -1,78 +1,7 @@
 #ifndef GAME_H
 #define GAME_H
 
-#include "global.hpp"
-#include <array>
-
-class point2D_t;
-
-enum Directions { UP, DOWN, RIGHT, LEFT };
-
 namespace Game {
-// private:
-enum ContinueStatus { STATUS_END_GAME = 0, STATUS_CONTINUE = 1 };
-enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
-
-enum GameStatusFlag {
-  FLAG_WIN,
-  FLAG_END_GAME,
-  FLAG_SAVED_GAME,
-  FLAG_INPUT_ERROR,
-  FLAG_ENDLESS_MODE,
-  FLAG_QUESTION_STAY_OR_QUIT,
-  MAX_NO_GAME_STATUS_FLAGS
-};
-
-using gamestatus_t = std::array<bool, MAX_NO_GAME_STATUS_FLAGS>;
-
-enum IntendedMoveFlag {
-  FLAG_MOVE_LEFT,
-  FLAG_MOVE_RIGHT,
-  FLAG_MOVE_UP,
-  FLAG_MOVE_DOWN,
-  MAX_NO_INTENDED_MOVE_FLAGS
-};
-
-using intendedmove_t = std::array<bool, MAX_NO_INTENDED_MOVE_FLAGS>;
-
-bool get_and_process_game_stats_string_data(std::istream &stats_file);
-bool load_game_stats_from_file(std::string filename);
-bool initialiseContinueBoardArray();
-bool soloGameLoop();
-void drawEndScreen();
-void drawBoard();
-void drawGameState();
-void drawScoreBoard(std::ostream &out_stream);
-bool check_input_ansi(char c);
-bool check_input_wasd(char c);
-bool check_input_vim(char c);
-bool check_input_other(char c);
-void input();
-void decideMove(Directions);
-
-bool collaspeTiles(point2D_t pt, point2D_t pt_offset);
-bool shiftTiles(point2D_t pt, point2D_t pt_offset);
-bool collasped_or_shifted_tiles(point2D_t pt, point2D_t pt_offset);
-bool check_recursive_offset_in_game_bounds(point2D_t pt, point2D_t pt_offset);
-
-void move(point2D_t pt, point2D_t pt_offset);
-void statistics();
-void saveStats();
-void saveScore();
-void saveState();
-void playGame(ContinueStatus);
-ull setBoardSize();
-
-void drawEndOfGamePrompt();
-void drawGraphics();
-void endlessGameLoop();
-void process_gamelogic();
-bool process_intendedMove();
-bool process_gameStatus();
-void drawInputError();
-void drawInputControls();
-
-// public:
 void startGame();
 void continueGame();
 }; // namespace Game

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -8,76 +8,73 @@ class point2D_t;
 
 enum Directions { UP, DOWN, RIGHT, LEFT };
 
-class Game {
-private:
-  enum ContinueStatus { STATUS_END_GAME = 0, STATUS_CONTINUE = 1 };
-  enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
+namespace Game {
+// private:
+enum ContinueStatus { STATUS_END_GAME = 0, STATUS_CONTINUE = 1 };
+enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
 
-  enum GameStatusFlag {
-    FLAG_WIN,
-    FLAG_END_GAME,
-    FLAG_SAVED_GAME,
-    FLAG_INPUT_ERROR,
-    FLAG_ENDLESS_MODE,
-    FLAG_QUESTION_STAY_OR_QUIT,
-    MAX_NO_GAME_STATUS_FLAGS
-  };
-
-  using gamestatus_t = std::array<bool, MAX_NO_GAME_STATUS_FLAGS>;
-
-  gamestatus_t gamestatus{};
-
-  enum IntendedMoveFlag {
-    FLAG_MOVE_LEFT,
-    FLAG_MOVE_RIGHT,
-    FLAG_MOVE_UP,
-    FLAG_MOVE_DOWN,
-    MAX_NO_INTENDED_MOVE_FLAGS
-  };
-
-  using intendedmove_t = std::array<bool, MAX_NO_INTENDED_MOVE_FLAGS>;
-  intendedmove_t intendedmove{};
-
-  bool get_and_process_game_stats_string_data(std::istream &stats_file);
-  bool load_game_stats_from_file(std::string filename);
-  bool initialiseContinueBoardArray();
-  bool soloGameLoop();
-  void drawEndScreen();
-  void drawBoard() const;
-  void drawGameState();
-  void drawScoreBoard(std::ostream &out_stream) const;
-  bool check_input_ansi(char c);
-  bool check_input_wasd(char c);
-  bool check_input_vim(char c);
-  bool check_input_other(char c);
-  void input();
-  void decideMove(Directions);
-
-  bool collaspeTiles(point2D_t pt, point2D_t pt_offset);
-  bool shiftTiles(point2D_t pt, point2D_t pt_offset);
-  bool collasped_or_shifted_tiles(point2D_t pt, point2D_t pt_offset);
-  bool check_recursive_offset_in_game_bounds(point2D_t pt, point2D_t pt_offset);
-
-  void move(point2D_t pt, point2D_t pt_offset);
-  void statistics() const;
-  void saveStats() const;
-  void saveScore() const;
-  void saveState() const;
-  void playGame(ContinueStatus);
-  ull setBoardSize();
-
-  void drawEndOfGamePrompt();
-  void drawGraphics();
-  void endlessGameLoop();
-  void process_gamelogic();
-  bool process_intendedMove();
-  bool process_gameStatus();
-  void drawInputError();
-  void drawInputControls();
-
-public:
-  void startGame();
-  void continueGame();
+enum GameStatusFlag {
+  FLAG_WIN,
+  FLAG_END_GAME,
+  FLAG_SAVED_GAME,
+  FLAG_INPUT_ERROR,
+  FLAG_ENDLESS_MODE,
+  FLAG_QUESTION_STAY_OR_QUIT,
+  MAX_NO_GAME_STATUS_FLAGS
 };
+
+using gamestatus_t = std::array<bool, MAX_NO_GAME_STATUS_FLAGS>;
+
+enum IntendedMoveFlag {
+  FLAG_MOVE_LEFT,
+  FLAG_MOVE_RIGHT,
+  FLAG_MOVE_UP,
+  FLAG_MOVE_DOWN,
+  MAX_NO_INTENDED_MOVE_FLAGS
+};
+
+using intendedmove_t = std::array<bool, MAX_NO_INTENDED_MOVE_FLAGS>;
+
+bool get_and_process_game_stats_string_data(std::istream &stats_file);
+bool load_game_stats_from_file(std::string filename);
+bool initialiseContinueBoardArray();
+bool soloGameLoop();
+void drawEndScreen();
+void drawBoard();
+void drawGameState();
+void drawScoreBoard(std::ostream &out_stream);
+bool check_input_ansi(char c);
+bool check_input_wasd(char c);
+bool check_input_vim(char c);
+bool check_input_other(char c);
+void input();
+void decideMove(Directions);
+
+bool collaspeTiles(point2D_t pt, point2D_t pt_offset);
+bool shiftTiles(point2D_t pt, point2D_t pt_offset);
+bool collasped_or_shifted_tiles(point2D_t pt, point2D_t pt_offset);
+bool check_recursive_offset_in_game_bounds(point2D_t pt, point2D_t pt_offset);
+
+void move(point2D_t pt, point2D_t pt_offset);
+void statistics();
+void saveStats();
+void saveScore();
+void saveState();
+void playGame(ContinueStatus);
+ull setBoardSize();
+
+void drawEndOfGamePrompt();
+void drawGraphics();
+void endlessGameLoop();
+void process_gamelogic();
+bool process_intendedMove();
+bool process_gameStatus();
+void drawInputError();
+void drawInputControls();
+
+// public:
+void startGame();
+void continueGame();
+}; // namespace Game
 
 #endif

--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -1,9 +1,10 @@
 #ifndef GAME_H
 #define GAME_H
 
-#include "gameboard.hpp"
 #include "global.hpp"
 #include <array>
+
+class point2D_t;
 
 enum Directions { UP, DOWN, RIGHT, LEFT };
 
@@ -36,12 +37,6 @@ private:
 
   using intendedmove_t = std::array<bool, MAX_NO_INTENDED_MOVE_FLAGS>;
   intendedmove_t intendedmove{};
-
-  ull bestScore;
-  double duration;
-  GameBoard gamePlayBoard;
-  RandInt randInt;
-  bool noSave;
 
   bool get_and_process_game_stats_string_data(std::istream &stats_file);
   bool load_game_stats_from_file(std::string filename);
@@ -81,7 +76,6 @@ private:
   void drawInputControls();
 
 public:
-  Game() : bestScore(0), duration(0.0), noSave(false) {}
   void startGame();
   void continueGame();
 };

--- a/src/headers/global.hpp
+++ b/src/headers/global.hpp
@@ -28,7 +28,6 @@ void DrawAsOneTimeFlag(std::ostream &os, bool &trigger, T f) {
 }
 
 void wait_for_any_letter_input(std::istream &is);
-void newline(int n = 1);
 void clearScreen();
 void drawAscii();
 std::string secondsFormat(double);

--- a/src/headers/global.hpp
+++ b/src/headers/global.hpp
@@ -1,10 +1,32 @@
 #ifndef GLOBAL_H
 #define GLOBAL_H
 
+#include <iosfwd>
 #include <string>
 
 using ull = unsigned long long;
 void getKeypressDownInput(char &);
+
+template<typename T>
+void DrawAlways(std::ostream &os, T f) {
+  os << f();
+}
+
+template<typename T>
+void DrawOnlyWhen(std::ostream &os, bool trigger, T f) {
+  if (trigger) {
+    DrawAlways(os, f);
+  }
+}
+
+template<typename T>
+void DrawAsOneTimeFlag(std::ostream &os, bool &trigger, T f) {
+  if (trigger) {
+    DrawAlways(os, f);
+    trigger = !trigger;
+  }
+}
+
 void wait_for_any_letter_input(std::istream &is);
 void newline(int n = 1);
 void clearScreen();

--- a/src/headers/global.hpp
+++ b/src/headers/global.hpp
@@ -4,7 +4,7 @@
 #include <string>
 
 using ull = unsigned long long;
-void getInput(char &);
+void getKeypressDownInput(char &);
 void wait_for_any_letter_input(std::istream &is);
 void newline(int n = 1);
 void clearScreen();

--- a/src/headers/loadresource.hpp
+++ b/src/headers/loadresource.hpp
@@ -1,0 +1,20 @@
+#ifndef LOADRESOURCE_H
+#define LOADRESOURCE_H
+
+#include "gameboard.hpp"
+#include <string>
+#include <tuple>
+
+namespace Game {
+namespace Loader {
+std::tuple<bool, GameBoard> load_GameBoard_data_from_file(std::string filename);
+
+// Output: {[loadfile_ok_status], [decltype(gameboard.score)],
+// [decltype(gameboard.moveCount)]}
+std::tuple<bool, std::tuple<unsigned long long, long long>>
+load_game_stats_from_file(std::string filename);
+
+} // namespace Loader
+} // namespace Game
+
+#endif

--- a/src/headers/loadresource.hpp
+++ b/src/headers/loadresource.hpp
@@ -5,9 +5,12 @@
 #include <string>
 #include <tuple>
 
+using load_gameboard_status_t = std::tuple<bool, GameBoard>;
+
 namespace Game {
 namespace Loader {
-std::tuple<bool, GameBoard> load_GameBoard_data_from_file(std::string filename);
+
+load_gameboard_status_t load_GameBoard_data_from_file(std::string filename);
 
 // Output: {[loadfile_ok_status], [decltype(gameboard.score)],
 // [decltype(gameboard.moveCount)]}

--- a/src/headers/saveresource.hpp
+++ b/src/headers/saveresource.hpp
@@ -1,0 +1,16 @@
+#ifndef SAVERESOURCE_H
+#define SAVERESOURCE_H
+
+#include "gameboard.hpp"
+#include <string>
+#include <tuple>
+
+namespace Game {
+namespace Saver {
+void saveToFilePreviousGameStateData(std::string filename, const GameBoard &gb);
+void saveToFilePreviousGameStatisticsData(std::string filename,
+                                          const GameBoard &gb);
+} // namespace Saver
+} // namespace Game
+
+#endif

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -18,7 +18,7 @@ struct total_game_stats_t {
 using load_stats_status_t = std::tuple<bool, total_game_stats_t>;
 
 load_stats_status_t loadFromFileStatistics(std::string filename);
-bool saveToFileStatistics(std::string filename, total_game_stats_t s);
+bool saveToFileEndGameStatistics(std::string filename, total_game_stats_t s);
 void prettyPrintStats(std::ostream &os);
 } // namespace Statistics
 

--- a/src/loadresource.cpp
+++ b/src/loadresource.cpp
@@ -107,8 +107,7 @@ get_and_process_game_stats_string_data(std::istream &stats_file) {
 
 } // namespace
 
-std::tuple<bool, GameBoard>
-load_GameBoard_data_from_file(std::string filename) {
+load_gameboard_status_t load_GameBoard_data_from_file(std::string filename) {
   std::ifstream stateFile(filename);
   if (stateFile) {
     const ull savedBoardPlaySize = GetLines(filename);

--- a/src/loadresource.cpp
+++ b/src/loadresource.cpp
@@ -1,0 +1,133 @@
+#include "loadresource.hpp"
+#include "gameboard.hpp"
+#include "global.hpp"
+#include <algorithm>
+#include <array>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace Game {
+namespace Loader {
+namespace {
+
+int GetLines(std::string filename) {
+  std::ifstream stateFile(filename);
+  using iter = std::istreambuf_iterator<char>;
+  const auto noOfLines = std::count(iter{stateFile}, iter{}, '\n');
+  return noOfLines;
+}
+
+std::vector<std::string> get_file_tile_data(std::istream &buf) {
+  std::vector<std::string> tempbuffer;
+  enum { MAX_WIDTH = 10, MAX_HEIGHT = 10 };
+  auto i{0};
+  for (std::string tempLine; std::getline(buf, tempLine) && i < MAX_WIDTH;
+       i++) {
+    std::istringstream temp_filestream(tempLine);
+    auto j{0};
+    for (std::string a_word;
+         std::getline(temp_filestream, a_word, ',') && j < MAX_HEIGHT; j++) {
+      tempbuffer.push_back(a_word);
+    }
+  }
+  return tempbuffer;
+}
+
+std::vector<Tile> process_file_tile_string_data(std::vector<std::string> buf) {
+  std::vector<Tile> result_buf;
+  auto tile_processed_counter{0};
+  const auto prime_tile_data =
+      [&tile_processed_counter](const std::string tile_data) {
+        enum FieldIndex { IDX_TILE_VALUE, IDX_TILE_BLOCKED, MAX_NO_TILE_IDXS };
+        std::array<int, MAX_NO_TILE_IDXS> tile_internal{};
+        std::istringstream blocks(tile_data);
+        auto idx_id{0};
+        for (std::string temptiledata; std::getline(
+                 blocks, temptiledata, ':') /*&& idx_id < MAX_NO_TILE_IDXS*/;
+             idx_id++) {
+          switch (idx_id) {
+          case IDX_TILE_VALUE:
+            std::get<IDX_TILE_VALUE>(tile_internal) = std::stoi(temptiledata);
+            break;
+          case IDX_TILE_BLOCKED:
+            std::get<IDX_TILE_BLOCKED>(tile_internal) = std::stoi(temptiledata);
+            break;
+          default:
+            std::cout << "ERROR: [tile_processed_counter: "
+                      << tile_processed_counter
+                      << "]: Read past MAX_NO_TILE_IDXS! (idx no:"
+                      << MAX_NO_TILE_IDXS << ")\n";
+          }
+        }
+        tile_processed_counter++;
+        return Tile(std::get<IDX_TILE_VALUE>(tile_internal),
+                    std::get<IDX_TILE_BLOCKED>(tile_internal));
+      };
+  std::transform(std::begin(buf), std::end(buf), std::back_inserter(result_buf),
+                 prime_tile_data);
+  return result_buf;
+}
+
+// TODO: Refactor and combine to one "gameboard" loader function!
+std::tuple<bool, std::tuple<unsigned long long, long long>>
+get_and_process_game_stats_string_data(std::istream &stats_file) {
+  if (stats_file) {
+    unsigned long long score;
+    long long moveCount;
+    for (std::string tempLine; std::getline(stats_file, tempLine);) {
+      enum GameStatsFieldIndex {
+        IDX_GAME_SCORE_VALUE,
+        IDX_GAME_MOVECOUNT,
+        MAX_NO_GAME_STATS_IDXS
+      };
+      std::istringstream line(tempLine);
+      auto idx_id{0};
+      for (std::string temp; std::getline(line, temp, ':'); idx_id++) {
+        switch (idx_id) {
+        case IDX_GAME_SCORE_VALUE:
+          score = std::stoi(temp);
+          break;
+        case IDX_GAME_MOVECOUNT:
+          moveCount = std::stoi(temp) - 1;
+          break;
+        default:
+          // Error: No fields to process!
+          break;
+        }
+      }
+    }
+    return std::make_tuple(true, std::make_tuple(score, moveCount));
+  }
+  return std::make_tuple(false, std::make_tuple(0, 0));
+}
+
+} // namespace
+
+std::tuple<bool, GameBoard>
+load_GameBoard_data_from_file(std::string filename) {
+  std::ifstream stateFile(filename);
+  if (stateFile) {
+    const ull savedBoardPlaySize = GetLines(filename);
+    const auto file_tile_data = get_file_tile_data(stateFile);
+    const auto processed_tile_data =
+        process_file_tile_string_data(file_tile_data);
+    return std::make_tuple(true,
+                           GameBoard(savedBoardPlaySize, processed_tile_data));
+  }
+  return std::make_tuple(false, GameBoard{});
+}
+
+// Output: [loadfile_ok_status, gameboard.score, gameboard.moveCount]
+std::tuple<bool, std::tuple<unsigned long long, long long>>
+load_game_stats_from_file(std::string filename) {
+  std::ifstream stats(filename);
+  return get_and_process_game_stats_string_data(stats);
+}
+
+} // namespace Loader
+
+} // namespace Game

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -25,13 +25,11 @@ mainmenustatus_t mainmenustatus{};
 bool FlagInputErrornousChoice{};
 
 void startGame() {
-  Game g;
-  g.startGame();
+  Game::startGame();
 }
 
 void continueGame() {
-  Game g;
-  g.continueGame();
+  Game::continueGame();
 }
 
 void showScores() {

--- a/src/saveresource.cpp
+++ b/src/saveresource.cpp
@@ -1,0 +1,35 @@
+#include "saveresource.hpp"
+#include "gameboard.hpp"
+#include <fstream>
+
+namespace Game {
+namespace Saver {
+namespace {
+
+bool generateFilefromPreviousGameStatisticsData(std::ostream &os,
+                                                const GameBoard &gb) {
+  os << gb.score << ":" << gb.MoveCount();
+  return true;
+}
+
+bool generateFilefromPreviousGameStateData(std::ostream &os,
+                                           const GameBoard &gb) {
+  os << gb.printState();
+  return true;
+}
+
+} // namespace
+
+void saveToFilePreviousGameStateData(std::string filename,
+                                     const GameBoard &gb) {
+  std::ofstream stateFile(filename, std::ios_base::app);
+  generateFilefromPreviousGameStateData(stateFile, gb);
+}
+
+void saveToFilePreviousGameStatisticsData(std::string filename,
+                                          const GameBoard &gb) {
+  std::ofstream stats(filename, std::ios_base::app);
+  generateFilefromPreviousGameStatisticsData(stats, gb);
+}
+} // namespace Saver
+} // namespace Game

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -32,7 +32,7 @@ load_stats_status_t loadFromFileStatistics(std::string filename) {
   return load_stats_status_t{false, total_game_stats_t{}};
 }
 
-bool saveToFileStatistics(std::string filename, total_game_stats_t s) {
+bool saveToFileEndGameStatistics(std::string filename, total_game_stats_t s) {
   std::ofstream filedata(filename);
   return generateFilefromStatsData(filedata, s);
 }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1,0 +1,12 @@
+#include "tile.hpp"
+#include <cmath>
+#include <vector>
+
+Color::Modifier Tile::tileColor(ull value) {
+  std::vector<Color::Modifier> colors{red, yellow, magenta, blue, cyan, yellow,
+                                      red, yellow, magenta, blue, green};
+  int log = log2(value);
+  int index = log < 12 ? log - 1 : 10;
+
+  return colors[index];
+}


### PR DESCRIPTION
Continued from PR #101 ...
_This is a large size PR and 98%~ complete so pushing changes._ :smiley: 

* Removes `Game` _class_ for a _namespace_.
* Added relevant `game-*` translation units _to help break up_ the large `game` translation unit.
* Removed a lot of _member variables_ of the previous `Game` _class_ into more local _function variables_.
* Moved _out-of-place functions_ (like `tileColor`) to better suited translation units.
* Introduced `loadresource` and `saveresource` _translation units_.
* A lot of _functions are now much more "stand-alone" and testable_!
* _Function names (and their parameters required)_ are much _more clearer and understandable_.
* _Repeated code / functionality_ has been _templated_. (See `Draw{Always,AsOneTimeFlag,OnlyWhen}`)

--
_Note: It may help to go through the commits in age order to understand the critical changes over time._
_(There are still a few more changes that could be applied but decided to make a separate PR for them)._