### PR TITLE
Fix: Issue #67

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -39,6 +39,11 @@ void getKeypressDownInput(char &c) {
 
 #endif
 
+void pause_for_keypress() {
+  char c{};
+  getKeypressDownInput(c);
+}
+
 void wait_for_any_letter_input(std::istream &is) {
   char c;
   is >> c;

--- a/src/headers/global.hpp
+++ b/src/headers/global.hpp
@@ -27,6 +27,7 @@ void DrawAsOneTimeFlag(std::ostream &os, bool &trigger, T f) {
   }
 }
 
+void pause_for_keypress();
 void wait_for_any_letter_input(std::istream &is);
 void clearScreen();
 void drawAscii();

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -37,8 +37,9 @@ void showScores() {
   drawAscii();
   Scoreboard::prettyPrintScoreboard(std::cout);
   Statistics::prettyPrintStats(std::cout);
-  wait_for_any_letter_input(std::cin);
-  exit(EXIT_SUCCESS);
+  std::cout << std::flush;
+  pause_for_keypress();
+  Menu::startMenu();
 }
 
 void drawMainMenuTitle(std::ostream &out_os) {

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -46,7 +46,8 @@ void prettyPrintStats(std::ostream &os) {
                                       "Number of Wins", "Total Moves Played",
                                       "Total Duration"};
   constexpr auto no_save_text = "No saved statistics.";
-  constexpr auto any_key_exit_text = "Press any key to exit: ";
+  constexpr auto any_key_exit_text =
+      "Press any key to return to the main menu... ";
   constexpr auto sp = "  ";
 
   std::ostringstream stats_richtext;


### PR DESCRIPTION
When user enters the highscore screen, a button press now returns the
user to the main-menu screen instead of quitting the program.
One can quit via the main-menu screen instead.