### PR TITLE
Fix: Convert Gameboard class to a namespaced area

### DIFF
--- a/src/game-pregamemenu.cpp
+++ b/src/game-pregamemenu.cpp
@@ -8,6 +8,7 @@
 #include "menu.hpp"
 #include <array>
 #include <iostream>
+#include <limits>
 #include <sstream>
 
 namespace Game {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12,6 +12,7 @@
 #include "statistics.hpp"
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <fstream>
 #include <iomanip>
 #include <iostream>

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -137,10 +137,10 @@ void drawInputControls(std::ostream &os, gamestatus_t gamestatus) {
 }
 
 gamestatus_t process_gamelogic(gamestatus_t gamestatus) {
-  gamePlayBoard.unblockTiles();
+  unblockTilesOnGameboard(gamePlayBoard);
   if (gamePlayBoard.moved) {
-    gamePlayBoard.addTile();
-    gamePlayBoard.registerMoveByOne();
+    addTileOnGameboard(gamePlayBoard);
+    registerMoveByOneOnGameboard(gamePlayBoard);
   }
 
   if (!gamestatus[FLAG_ENDLESS_MODE]) {
@@ -149,7 +149,7 @@ gamestatus_t process_gamelogic(gamestatus_t gamestatus) {
       gamestatus[FLAG_QUESTION_STAY_OR_QUIT] = true;
     }
   }
-  if (!gamePlayBoard.canMove()) {
+  if (!canMoveOnGameboard(gamePlayBoard)) {
     gamestatus[FLAG_END_GAME] = true;
   }
   return gamestatus;
@@ -213,19 +213,19 @@ gamestatus_t receive_agent_input(Input::intendedmove_t &intendedmove,
 void decideMove(Directions d) {
   switch (d) {
   case UP:
-    gamePlayBoard.tumbleTilesUp();
+    tumbleTilesUpOnGameboard(gamePlayBoard);
     break;
 
   case DOWN:
-    gamePlayBoard.tumbleTilesDown();
+    tumbleTilesDownOnGameboard(gamePlayBoard);
     break;
 
   case LEFT:
-    gamePlayBoard.tumbleTilesLeft();
+    tumbleTilesLeftOnGameboard(gamePlayBoard);
     break;
 
   case RIGHT:
-    gamePlayBoard.tumbleTilesRight();
+    tumbleTilesRightOnGameboard(gamePlayBoard);
     break;
   }
 }
@@ -420,7 +420,7 @@ void playGame(PlayGameFlag cont, GameBoard gb, ull userInput_PlaySize) {
   gamePlayBoard = gb;
   if (cont == PlayGameFlag::BrandNewGame) {
     gamePlayBoard = GameBoard(userInput_PlaySize);
-    gamePlayBoard.addTile();
+    addTileOnGameboard(gamePlayBoard);
   }
 
   const auto startTime = std::chrono::high_resolution_clock::now();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -93,7 +93,7 @@ void drawScoreBoard(std::ostream &os) {
                     border_padding_char)
      << gamePlayBoard.score << inner_border_padding << vertical_border_pattern
      << "\n";
-  if (gamePlayBoard.gbda.playsize == COMPETITION_GAME_BOARD_PLAY_SIZE) {
+  if (std::get<0>(gamePlayBoard.gbda) == COMPETITION_GAME_BOARD_PLAY_SIZE) {
     const auto tempBestScore =
         (bestScore < gamePlayBoard.score ? gamePlayBoard.score : bestScore);
     os << outer_border_padding << vertical_border_pattern
@@ -392,7 +392,7 @@ void saveScore(Scoreboard::Score finalscore) {
 }
 
 void DoPostGameSaveStuff(double duration) {
-  if (gamePlayBoard.gbda.playsize == COMPETITION_GAME_BOARD_PLAY_SIZE) {
+  if (std::get<0>(gamePlayBoard.gbda) == COMPETITION_GAME_BOARD_PLAY_SIZE) {
     Scoreboard::Score finalscore{};
     finalscore.score = gamePlayBoard.score;
     finalscore.win = hasWonOnGameboard(gamePlayBoard);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -92,8 +92,7 @@ void drawScoreBoard(std::ostream &os) {
                     border_padding_char)
      << gamePlayBoard.score << inner_border_padding << vertical_border_pattern
      << "\n";
-  if (getPlaySizeOfGameboard(gamePlayBoard) ==
-      COMPETITION_GAME_BOARD_PLAY_SIZE) {
+  if (gamePlayBoard.gbda.playsize == COMPETITION_GAME_BOARD_PLAY_SIZE) {
     const auto tempBestScore =
         (bestScore < gamePlayBoard.score ? gamePlayBoard.score : bestScore);
     os << outer_border_padding << vertical_border_pattern
@@ -392,8 +391,7 @@ void saveScore(Scoreboard::Score finalscore) {
 }
 
 void DoPostGameSaveStuff(double duration) {
-  if (getPlaySizeOfGameboard(gamePlayBoard) ==
-      COMPETITION_GAME_BOARD_PLAY_SIZE) {
+  if (gamePlayBoard.gbda.playsize == COMPETITION_GAME_BOARD_PLAY_SIZE) {
     Scoreboard::Score finalscore{};
     finalscore.score = gamePlayBoard.score;
     finalscore.win = hasWonOnGameboard(gamePlayBoard);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -92,7 +92,8 @@ void drawScoreBoard(std::ostream &os) {
                     border_padding_char)
      << gamePlayBoard.score << inner_border_padding << vertical_border_pattern
      << "\n";
-  if (gamePlayBoard.getPlaySize() == COMPETITION_GAME_BOARD_PLAY_SIZE) {
+  if (getPlaySizeOfGameboard(gamePlayBoard) ==
+      COMPETITION_GAME_BOARD_PLAY_SIZE) {
     const auto tempBestScore =
         (bestScore < gamePlayBoard.score ? gamePlayBoard.score : bestScore);
     os << outer_border_padding << vertical_border_pattern
@@ -106,11 +107,11 @@ void drawScoreBoard(std::ostream &os) {
   }
   os << outer_border_padding << vertical_border_pattern << inner_border_padding
      << bold_on << moves_text_label << bold_off
-     << std::string(inner_padding_length -
-                        std::string{moves_text_label}.length() -
-                        std::to_string(gamePlayBoard.MoveCount()).length(),
-                    border_padding_char)
-     << gamePlayBoard.MoveCount() << inner_border_padding
+     << std::string(
+            inner_padding_length - std::string{moves_text_label}.length() -
+                std::to_string(MoveCountOnGameBoard(gamePlayBoard)).length(),
+            border_padding_char)
+     << MoveCountOnGameBoard(gamePlayBoard) << inner_border_padding
      << vertical_border_pattern << "\n";
   os << outer_border_padding << bottom_board << "\n \n";
 }
@@ -143,7 +144,7 @@ gamestatus_t process_gamelogic(gamestatus_t gamestatus) {
   }
 
   if (!gamestatus[FLAG_ENDLESS_MODE]) {
-    if (gamePlayBoard.hasWon()) {
+    if (hasWonOnGameboard(gamePlayBoard)) {
       gamestatus[FLAG_WIN] = true;
       gamestatus[FLAG_QUESTION_STAY_OR_QUIT] = true;
     }
@@ -391,11 +392,12 @@ void saveScore(Scoreboard::Score finalscore) {
 }
 
 void DoPostGameSaveStuff(double duration) {
-  if (gamePlayBoard.getPlaySize() == COMPETITION_GAME_BOARD_PLAY_SIZE) {
+  if (getPlaySizeOfGameboard(gamePlayBoard) ==
+      COMPETITION_GAME_BOARD_PLAY_SIZE) {
     Scoreboard::Score finalscore{};
     finalscore.score = gamePlayBoard.score;
-    finalscore.win = gamePlayBoard.hasWon();
-    finalscore.moveCount = gamePlayBoard.MoveCount();
+    finalscore.win = hasWonOnGameboard(gamePlayBoard);
+    finalscore.moveCount = MoveCountOnGameBoard(gamePlayBoard);
     finalscore.largestTile = gamePlayBoard.largestTile;
     finalscore.duration = duration;
 

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -104,16 +104,16 @@ ull getTileValueOnGameboard(GameBoard gb, point2D_t pt) {
   return gb.board[point2D_to_1D_index(gb, pt)].value;
 }
 
-void GameBoard::setTileValue(point2D_t pt, ull value) {
-  board[point2D_to_1D_index(*this, pt)].value = value;
+void setTileValueOnGameboard(GameBoard &gb, point2D_t pt, ull value) {
+  gb.board[point2D_to_1D_index(gb, pt)].value = value;
 }
 
 bool getTileBlockedOnGameboard(GameBoard gb, point2D_t pt) {
   return gb.board[point2D_to_1D_index(gb, pt)].blocked;
 }
 
-void GameBoard::setTileBlocked(point2D_t pt, bool blocked) {
-  board[point2D_to_1D_index(*this, pt)].blocked = blocked;
+void setTileBlockedOnGameboard(GameBoard &gb, point2D_t pt, bool blocked) {
+  gb.board[point2D_to_1D_index(gb, pt)].blocked = blocked;
 }
 
 int GameBoard::getPlaySize() const {
@@ -181,7 +181,7 @@ bool GameBoard::addTile() {
   const auto randomFreeTile = freeTiles.at(RandInt{}() % freeTiles.size());
   const auto value_four_or_two =
       RandInt{}() % 100 > CHANCE_OF_VALUE_FOUR_OVER_TWO ? 4 : 2;
-  setTileValue(randomFreeTile, value_four_or_two);
+  setTileValueOnGameboard(*this, randomFreeTile, value_four_or_two);
 
   return false;
 }

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -195,36 +195,37 @@ bool canMoveOnGameboardDataArray(gameboard_data_array_t &gbda) {
                      can_move_to_offset);
 }
 
-std::vector<point2D_t>
+std::vector<int>
 collectFreeTilesOnGameboardDataArray(gameboard_data_array_t gbda) {
-  std::vector<point2D_t> freeTiles;
+  std::vector<int> freeTiles;
   auto index_counter{0};
-  const auto gatherFreePoint = [gbda, &freeTiles,
-                                &index_counter](const Tile t) {
-    const auto current_point =
-        point2D_t{index_counter % getPlaySizeOfGameboardDataArray(gbda),
-                  index_counter / getPlaySizeOfGameboardDataArray(gbda)};
+  for (const auto t : gbda.board) {
     if (!t.value) {
-      freeTiles.push_back(current_point);
+      freeTiles.push_back(index_counter);
     }
     index_counter++;
-  };
-  std::for_each(std::begin(gbda.board), std::end(gbda.board), gatherFreePoint);
+  }
   return freeTiles;
 }
 
 bool addTileOnGameboardDataArray(gameboard_data_array_t &gbda) {
   constexpr auto CHANCE_OF_VALUE_FOUR_OVER_TWO = 89; // Percentage
-  const auto freeTiles = collectFreeTilesOnGameboardDataArray(gbda);
+  const auto index_list_of_free_tiles =
+      collectFreeTilesOnGameboardDataArray(gbda);
 
-  if (!freeTiles.size()) {
+  if (!index_list_of_free_tiles.size()) {
     return true;
   }
 
-  const auto randomFreeTile = freeTiles.at(RandInt{}() % freeTiles.size());
+  const auto rand_selected_index = index_list_of_free_tiles.at(
+      RandInt{}() % index_list_of_free_tiles.size());
+  const auto rand_index_as_point_t =
+      point2D_t{rand_selected_index % getPlaySizeOfGameboardDataArray(gbda),
+                rand_selected_index / getPlaySizeOfGameboardDataArray(gbda)};
   const auto value_four_or_two =
       RandInt{}() % 100 > CHANCE_OF_VALUE_FOUR_OVER_TWO ? 4 : 2;
-  setTileValueOnGameboardDataArray(gbda, randomFreeTile, value_four_or_two);
+  setTileValueOnGameboardDataArray(gbda, rand_index_as_point_t,
+                                   value_four_or_two);
 
   return false;
 }

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -34,34 +34,43 @@ size_t getPlaySizeOfGameboardDataArray(gameboard_data_array_t gbda) {
   return std::get<IDX_PLAYSIZE>(gbda);
 }
 
-int point2D_to_1D_index(gameboard_data_array_t gbda, point2D_t pt) {
-  int x, y;
-  std::tie(x, y) = pt.get();
-  return x + getPlaySizeOfGameboardDataArray(gbda) * y;
-}
+struct gameboard_data_point_t {
+  static int point2D_to_1D_index(gameboard_data_array_t gbda, point2D_t pt) {
+    int x, y;
+    std::tie(x, y) = pt.get();
+    return x + getPlaySizeOfGameboardDataArray(gbda) * y;
+  }
+
+  Tile operator()(gameboard_data_array_t gbda, point2D_t pt) const {
+    return std::get<IDX_BOARD>(gbda)[point2D_to_1D_index(gbda, pt)];
+  }
+  Tile &operator()(gameboard_data_array_t &gbda, point2D_t pt) {
+    return std::get<IDX_BOARD>(gbda)[point2D_to_1D_index(gbda, pt)];
+  }
+};
 
 Tile getTileOnGameboardDataArray(gameboard_data_array_t gbda, point2D_t pt) {
-  return std::get<IDX_BOARD>(gbda)[point2D_to_1D_index(gbda, pt)];
+  return gameboard_data_point_t{}(gbda, pt);
 }
 
 void setTileOnGameboardDataArray(gameboard_data_array_t &gbda, point2D_t pt,
                                  Tile tile) {
-  std::get<IDX_BOARD>(gbda)[point2D_to_1D_index(gbda, pt)] = tile;
+  gameboard_data_point_t{}(gbda, pt) = tile;
 }
 
 ull getTileValueOnGameboardDataArray(gameboard_data_array_t gbda,
                                      point2D_t pt) {
-  return std::get<IDX_BOARD>(gbda)[point2D_to_1D_index(gbda, pt)].value;
+  return gameboard_data_point_t{}(gbda, pt).value;
 }
 
 void setTileValueOnGameboardDataArray(gameboard_data_array_t &gbda,
                                       point2D_t pt, ull value) {
-  std::get<IDX_BOARD>(gbda)[point2D_to_1D_index(gbda, pt)].value = value;
+  gameboard_data_point_t{}(gbda, pt).value = value;
 }
 
 bool getTileBlockedOnGameboardDataArray(gameboard_data_array_t gbda,
                                         point2D_t pt) {
-  return std::get<IDX_BOARD>(gbda)[point2D_to_1D_index(gbda, pt)].blocked;
+  return gameboard_data_point_t{}(gbda, pt).blocked;
 }
 
 template<size_t num_of_bars>

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -228,20 +228,20 @@ long long MoveCountOnGameBoard(GameBoard gb) {
   return gb.moveCount;
 }
 
-void GameBoard::unblockTiles() {
-  std::transform(std::begin(board), std::end(board), std::begin(board),
+void unblockTilesOnGameboard(GameBoard &gb) {
+  std::transform(std::begin(gb.board), std::end(gb.board), std::begin(gb.board),
                  [](const Tile t) {
                    return Tile{t.value, false};
                  });
 }
 
-bool GameBoard::canMove() {
+bool canMoveOnGameboard(GameBoard &gb) {
   auto index_counter{0};
 
-  const auto can_move_to_offset = [this, &index_counter](const Tile t) {
+  const auto can_move_to_offset = [=, &index_counter](const Tile t) {
     const auto current_point =
-        point2D_t{index_counter % getPlaySizeOfGameboard(*this),
-                  index_counter / getPlaySizeOfGameboard(*this)};
+        point2D_t{index_counter % getPlaySizeOfGameboard(gb),
+                  index_counter / getPlaySizeOfGameboard(gb)};
     index_counter++;
     const auto list_of_offsets = {point2D_t{1, 0}, point2D_t{0, 1}};
     const auto current_point_value = t.value;
@@ -252,8 +252,8 @@ bool GameBoard::canMove() {
           current_point - offset}; // Negative adjacent Check
       for (const auto current_offset : offset_check) {
         if (is_point_in_board_play_area(current_offset,
-                                        getPlaySizeOfGameboard(*this))) {
-          return getTileValueOnGameboard(*this, current_offset) ==
+                                        getPlaySizeOfGameboard(gb))) {
+          return getTileValueOnGameboard(gb, current_offset) ==
                  current_point_value;
         }
       }
@@ -264,17 +264,18 @@ bool GameBoard::canMove() {
             std::any_of(std::begin(list_of_offsets), std::end(list_of_offsets),
                         offset_in_range_with_same_value));
   };
-  return std::any_of(std::begin(board), std::end(board), can_move_to_offset);
+  return std::any_of(std::begin(gb.board), std::end(gb.board),
+                     can_move_to_offset);
 }
 
-void GameBoard::registerMoveByOne() {
-  moveCount++;
-  moved = false;
+void registerMoveByOneOnGameboard(GameBoard &gb) {
+  gb.moveCount++;
+  gb.moved = false;
 }
 
-bool GameBoard::addTile() {
+bool addTileOnGameboard(GameBoard &gb) {
   constexpr auto CHANCE_OF_VALUE_FOUR_OVER_TWO = 89; // Percentage
-  const auto freeTiles = collectFreeTilesOnGameboard(*this);
+  const auto freeTiles = collectFreeTilesOnGameboard(gb);
 
   if (!freeTiles.size()) {
     return true;
@@ -283,57 +284,57 @@ bool GameBoard::addTile() {
   const auto randomFreeTile = freeTiles.at(RandInt{}() % freeTiles.size());
   const auto value_four_or_two =
       RandInt{}() % 100 > CHANCE_OF_VALUE_FOUR_OVER_TWO ? 4 : 2;
-  setTileValueOnGameboard(*this, randomFreeTile, value_four_or_two);
+  setTileValueOnGameboard(gb, randomFreeTile, value_four_or_two);
 
   return false;
 }
 
-void GameBoard::tumbleTilesUp() {
-  for (int x = 0; x < getPlaySizeOfGameboard(*this); x++) {
+void tumbleTilesUpOnGameboard(GameBoard &gb) {
+  for (int x = 0; x < getPlaySizeOfGameboard(gb); x++) {
     int y = 1;
-    while (y < getPlaySizeOfGameboard(*this)) {
+    while (y < getPlaySizeOfGameboard(gb)) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboard(*this, current_point)) {
-        moveOnGameboard(*this, current_point, point2D_t{0, -1});
+      if (getTileValueOnGameboard(gb, current_point)) {
+        moveOnGameboard(gb, current_point, point2D_t{0, -1});
       }
       y++;
     }
   }
 }
 
-void GameBoard::tumbleTilesDown() {
-  for (int x = 0; x < getPlaySizeOfGameboard(*this); x++) {
-    int y = getPlaySizeOfGameboard(*this) - 2;
+void tumbleTilesDownOnGameboard(GameBoard &gb) {
+  for (int x = 0; x < getPlaySizeOfGameboard(gb); x++) {
+    int y = getPlaySizeOfGameboard(gb) - 2;
     while (y >= 0) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboard(*this, current_point)) {
-        moveOnGameboard(*this, current_point, point2D_t{0, 1});
+      if (getTileValueOnGameboard(gb, current_point)) {
+        moveOnGameboard(gb, current_point, point2D_t{0, 1});
       }
       y--;
     }
   }
 }
 
-void GameBoard::tumbleTilesLeft() {
-  for (int y = 0; y < getPlaySizeOfGameboard(*this); y++) {
+void tumbleTilesLeftOnGameboard(GameBoard &gb) {
+  for (int y = 0; y < getPlaySizeOfGameboard(gb); y++) {
     int x = 1;
-    while (x < getPlaySizeOfGameboard(*this)) {
+    while (x < getPlaySizeOfGameboard(gb)) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboard(*this, current_point)) {
-        moveOnGameboard(*this, current_point, {-1, 0});
+      if (getTileValueOnGameboard(gb, current_point)) {
+        moveOnGameboard(gb, current_point, {-1, 0});
       }
       x++;
     }
   }
 }
 
-void GameBoard::tumbleTilesRight() {
-  for (int y = 0; y < getPlaySizeOfGameboard(*this); y++) {
-    int x = getPlaySizeOfGameboard(*this) - 2;
+void tumbleTilesRightOnGameboard(GameBoard &gb) {
+  for (int y = 0; y < getPlaySizeOfGameboard(gb); y++) {
+    int x = getPlaySizeOfGameboard(gb) - 2;
     while (x >= 0) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboard(*this, current_point)) {
-        moveOnGameboard(*this, current_point, point2D_t{1, 0});
+      if (getTileValueOnGameboard(gb, current_point)) {
+        moveOnGameboard(gb, current_point, point2D_t{1, 0});
       }
       x--;
     }

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -6,13 +6,6 @@
 
 namespace {
 
-// Pre-declare function signature for organisational reasons.
-Tile getTileOnGameboard(gameboard_data_array_t gbda, point2D_t pt);
-
-int getPlaySizeOfGameboard(gameboard_data_array_t gbda) {
-  return gbda.playsize;
-}
-
 std::string drawTileString(Tile currentTile) {
   std::ostringstream tile_richtext;
   if (!currentTile.value) {
@@ -22,6 +15,37 @@ std::string drawTileString(Tile currentTile) {
                   << std::setw(4) << currentTile.value << bold_off << def;
   }
   return tile_richtext.str();
+}
+
+int getPlaySizeOfGameboard(gameboard_data_array_t gbda) {
+  return gbda.playsize;
+}
+
+int point2D_to_1D_index(gameboard_data_array_t gbda, point2D_t pt) {
+  int x, y;
+  std::tie(x, y) = pt.get();
+  return x + getPlaySizeOfGameboard(gbda) * y;
+}
+
+Tile getTileOnGameboard(gameboard_data_array_t gbda, point2D_t pt) {
+  return gbda.board[point2D_to_1D_index(gbda, pt)];
+}
+
+void setTileOnGameboard(gameboard_data_array_t &gbda, point2D_t pt, Tile tile) {
+  gbda.board[point2D_to_1D_index(gbda, pt)] = tile;
+}
+
+ull getTileValueOnGameboard(gameboard_data_array_t gbda, point2D_t pt) {
+  return gbda.board[point2D_to_1D_index(gbda, pt)].value;
+}
+
+void setTileValueOnGameboard(gameboard_data_array_t &gbda, point2D_t pt,
+                             ull value) {
+  gbda.board[point2D_to_1D_index(gbda, pt)].value = value;
+}
+
+bool getTileBlockedOnGameboard(gameboard_data_array_t gbda, point2D_t pt) {
+  return gbda.board[point2D_to_1D_index(gbda, pt)].blocked;
 }
 
 template<int num_of_bars>
@@ -101,12 +125,6 @@ bool check_recursive_offset_in_game_bounds(point2D_t pt, point2D_t pt_offset,
   return (is_inside_outer_bounds || is_inside_inner_bounds);
 }
 
-int point2D_to_1D_index(gameboard_data_array_t gbda, point2D_t pt) {
-  int x, y;
-  std::tie(x, y) = pt.get();
-  return x + getPlaySizeOfGameboard(gbda) * y;
-}
-
 std::vector<point2D_t>
 collectFreeTilesOnGameboard(gameboard_data_array_t gbda) {
   std::vector<point2D_t> freeTiles;
@@ -123,27 +141,6 @@ collectFreeTilesOnGameboard(gameboard_data_array_t gbda) {
   };
   std::for_each(std::begin(gbda.board), std::end(gbda.board), gatherFreePoint);
   return freeTiles;
-}
-
-Tile getTileOnGameboard(gameboard_data_array_t gbda, point2D_t pt) {
-  return gbda.board[point2D_to_1D_index(gbda, pt)];
-}
-
-void setTileOnGameboard(gameboard_data_array_t &gbda, point2D_t pt, Tile tile) {
-  gbda.board[point2D_to_1D_index(gbda, pt)] = tile;
-}
-
-ull getTileValueOnGameboard(gameboard_data_array_t gbda, point2D_t pt) {
-  return gbda.board[point2D_to_1D_index(gbda, pt)].value;
-}
-
-void setTileValueOnGameboard(gameboard_data_array_t &gbda, point2D_t pt,
-                             ull value) {
-  gbda.board[point2D_to_1D_index(gbda, pt)].value = value;
-}
-
-bool getTileBlockedOnGameboard(gameboard_data_array_t gbda, point2D_t pt) {
-  return gbda.board[point2D_to_1D_index(gbda, pt)].blocked;
 }
 
 void discoverLargestTileValueOnGameboard(GameBoard gb, Tile targetTile) {

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -340,6 +340,58 @@ void moveOnGameboard(GameBoard &gb, delta_t dt_point) {
   }
 }
 
+void doTumbleTilesUpOnGameboard(GameBoard &gb) {
+  for (int x = 0; x < getPlaySizeOfGameboardDataArray(gb.gbda); x++) {
+    int y = 1;
+    while (y < getPlaySizeOfGameboardDataArray(gb.gbda)) {
+      const auto current_point = point2D_t{x, y};
+      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
+        moveOnGameboard(gb, std::make_pair(current_point, point2D_t{0, -1}));
+      }
+      y++;
+    }
+  }
+}
+
+void doTumbleTilesDownOnGameboard(GameBoard &gb) {
+  for (int x = 0; x < getPlaySizeOfGameboardDataArray(gb.gbda); x++) {
+    int y = getPlaySizeOfGameboardDataArray(gb.gbda) - 2;
+    while (y >= 0) {
+      const auto current_point = point2D_t{x, y};
+      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
+        moveOnGameboard(gb, std::make_pair(current_point, point2D_t{0, 1}));
+      }
+      y--;
+    }
+  }
+}
+
+void doTumbleTilesLeftOnGameboard(GameBoard &gb) {
+  for (int y = 0; y < getPlaySizeOfGameboardDataArray(gb.gbda); y++) {
+    int x = 1;
+    while (x < getPlaySizeOfGameboardDataArray(gb.gbda)) {
+      const auto current_point = point2D_t{x, y};
+      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
+        moveOnGameboard(gb, std::make_pair(current_point, point2D_t{-1, 0}));
+      }
+      x++;
+    }
+  }
+}
+
+void doTumbleTilesRightOnGameboard(GameBoard &gb) {
+  for (int y = 0; y < getPlaySizeOfGameboardDataArray(gb.gbda); y++) {
+    int x = getPlaySizeOfGameboardDataArray(gb.gbda) - 2;
+    while (x >= 0) {
+      const auto current_point = point2D_t{x, y};
+      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
+        moveOnGameboard(gb, std::make_pair(current_point, point2D_t{1, 0}));
+      }
+      x--;
+    }
+  }
+}
+
 } // namespace
 
 bool hasWonOnGameboard(GameBoard gb) {
@@ -368,55 +420,19 @@ bool addTileOnGameboard(GameBoard &gb) {
 }
 
 void tumbleTilesUpOnGameboard(GameBoard &gb) {
-  for (int x = 0; x < getPlaySizeOfGameboardDataArray(gb.gbda); x++) {
-    int y = 1;
-    while (y < getPlaySizeOfGameboardDataArray(gb.gbda)) {
-      const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
-        moveOnGameboard(gb, std::make_pair(current_point, point2D_t{0, -1}));
-      }
-      y++;
-    }
-  }
+  doTumbleTilesUpOnGameboard(gb);
 }
 
 void tumbleTilesDownOnGameboard(GameBoard &gb) {
-  for (int x = 0; x < getPlaySizeOfGameboardDataArray(gb.gbda); x++) {
-    int y = getPlaySizeOfGameboardDataArray(gb.gbda) - 2;
-    while (y >= 0) {
-      const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
-        moveOnGameboard(gb, std::make_pair(current_point, point2D_t{0, 1}));
-      }
-      y--;
-    }
-  }
+  doTumbleTilesDownOnGameboard(gb);
 }
 
 void tumbleTilesLeftOnGameboard(GameBoard &gb) {
-  for (int y = 0; y < getPlaySizeOfGameboardDataArray(gb.gbda); y++) {
-    int x = 1;
-    while (x < getPlaySizeOfGameboardDataArray(gb.gbda)) {
-      const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
-        moveOnGameboard(gb, std::make_pair(current_point, point2D_t{-1, 0}));
-      }
-      x++;
-    }
-  }
+  doTumbleTilesLeftOnGameboard(gb);
 }
 
 void tumbleTilesRightOnGameboard(GameBoard &gb) {
-  for (int y = 0; y < getPlaySizeOfGameboardDataArray(gb.gbda); y++) {
-    int x = getPlaySizeOfGameboardDataArray(gb.gbda) - 2;
-    while (x >= 0) {
-      const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
-        moveOnGameboard(gb, std::make_pair(current_point, point2D_t{1, 0}));
-      }
-      x--;
-    }
-  }
+  doTumbleTilesRightOnGameboard(gb);
 }
 
 std::string printStateOfGameBoard(GameBoard gb) {

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -28,6 +28,7 @@ private:
   std::uniform_int_distribution<> dist;
 };
 
+using gameboard_data_array_t = GameBoard::gameboard_data_array_t;
 enum gameboard_data_array_fields { IDX_PLAYSIZE, IDX_BOARD, MAX_NO_INDEXES };
 
 size_t getPlaySizeOfGameboardDataArray(gameboard_data_array_t gbda) {
@@ -169,6 +170,7 @@ bool check_recursive_offset_in_game_bounds(delta_t dt_point, int playsize) {
 
 gameboard_data_array_t
 unblockTilesOnGameboardDataArray(gameboard_data_array_t gbda) {
+  using tile_data_array_t = GameBoard::tile_data_array_t;
   auto new_board_data_array =
       tile_data_array_t(std::get<IDX_BOARD>(gbda).size());
   std::transform(std::begin(std::get<IDX_BOARD>(gbda)),
@@ -411,6 +413,13 @@ void doTumbleTilesRightOnGameboard(GameBoard &gb) {
 }
 
 } // namespace
+
+GameBoard::GameBoard(ull playsize)
+    : GameBoard{playsize, tile_data_array_t(playsize * playsize)} {
+}
+GameBoard::GameBoard(ull playsize, tile_data_array_t prempt_board)
+    : gbda{playsize, prempt_board} {
+}
 
 bool hasWonOnGameboard(GameBoard gb) {
   return gb.win;

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -115,28 +115,29 @@ std::vector<point2D_t> collectFreeTilesOnGameboard(GameBoard gb) {
     }
     index_counter++;
   };
-  std::for_each(std::begin(gb.board), std::end(gb.board), gatherFreePoint);
+  std::for_each(std::begin(gb.gbda.board), std::end(gb.gbda.board),
+                gatherFreePoint);
   return freeTiles;
 }
 
 Tile getTileOnGameboard(GameBoard gb, point2D_t pt) {
-  return gb.board[point2D_to_1D_index(gb, pt)];
+  return gb.gbda.board[point2D_to_1D_index(gb, pt)];
 }
 
 void setTileOnGameboard(GameBoard &gb, point2D_t pt, Tile tile) {
-  gb.board[point2D_to_1D_index(gb, pt)] = tile;
+  gb.gbda.board[point2D_to_1D_index(gb, pt)] = tile;
 }
 
 ull getTileValueOnGameboard(GameBoard gb, point2D_t pt) {
-  return gb.board[point2D_to_1D_index(gb, pt)].value;
+  return gb.gbda.board[point2D_to_1D_index(gb, pt)].value;
 }
 
 void setTileValueOnGameboard(GameBoard &gb, point2D_t pt, ull value) {
-  gb.board[point2D_to_1D_index(gb, pt)].value = value;
+  gb.gbda.board[point2D_to_1D_index(gb, pt)].value = value;
 }
 
 bool getTileBlockedOnGameboard(GameBoard gb, point2D_t pt) {
-  return gb.board[point2D_to_1D_index(gb, pt)].blocked;
+  return gb.gbda.board[point2D_to_1D_index(gb, pt)].blocked;
 }
 
 void discoverLargestTileValueOnGameboard(GameBoard gb, Tile targetTile) {
@@ -217,7 +218,7 @@ void moveOnGameboard(GameBoard &gb, point2D_t pt, point2D_t pt_offset) {
 } // namespace
 
 int getPlaySizeOfGameboard(GameBoard gb) {
-  return gb.playsize;
+  return gb.gbda.playsize;
 }
 
 bool hasWonOnGameboard(GameBoard gb) {
@@ -229,8 +230,8 @@ long long MoveCountOnGameBoard(GameBoard gb) {
 }
 
 void unblockTilesOnGameboard(GameBoard &gb) {
-  std::transform(std::begin(gb.board), std::end(gb.board), std::begin(gb.board),
-                 [](const Tile t) {
+  std::transform(std::begin(gb.gbda.board), std::end(gb.gbda.board),
+                 std::begin(gb.gbda.board), [](const Tile t) {
                    return Tile{t.value, false};
                  });
 }
@@ -264,7 +265,7 @@ bool canMoveOnGameboard(GameBoard &gb) {
             std::any_of(std::begin(list_of_offsets), std::end(list_of_offsets),
                         offset_in_range_with_same_value));
   };
-  return std::any_of(std::begin(gb.board), std::end(gb.board),
+  return std::any_of(std::begin(gb.gbda.board), std::end(gb.gbda.board),
                      can_move_to_offset);
 }
 

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -1,4 +1,5 @@
 #include "gameboard.hpp"
+#include "point2d.hpp"
 #include <algorithm>
 #include <array>
 #include <chrono>

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -209,6 +209,20 @@ std::string GameBoard::drawSelf() const {
   return str_os.str();
 }
 
+void discoverLargestTileValueOnGameboard(GameBoard gb, Tile targetTile) {
+  gb.largestTile =
+      gb.largestTile < targetTile.value ? targetTile.value : gb.largestTile;
+}
+
+void discoverWinningTileValueOnGameboard(GameBoard gb, Tile targetTile) {
+  if (!gb.hasWon()) {
+    constexpr auto GAME_TILE_WINNING_SCORE = 2048;
+    if (targetTile.value == GAME_TILE_WINNING_SCORE) {
+      gb.win = true;
+    }
+  }
+}
+
 bool collaspeTilesOnGameboard(GameBoard &gb, point2D_t pt,
                               point2D_t pt_offset) {
   Tile currentTile = getTileOnGameboard(gb, pt);
@@ -258,20 +272,6 @@ bool collasped_or_shifted_tilesOnGameboard(GameBoard &gb, point2D_t pt,
     return shiftTilesOnGameboard(gb, pt, pt_offset);
   }
   return false;
-}
-
-void discoverLargestTileValueOnGameboard(GameBoard gb, Tile targetTile) {
-  gb.largestTile =
-      gb.largestTile < targetTile.value ? targetTile.value : gb.largestTile;
-}
-
-void discoverWinningTileValueOnGameboard(GameBoard gb, Tile targetTile) {
-  if (!gb.hasWon()) {
-    constexpr auto GAME_TILE_WINNING_SCORE = 2048;
-    if (targetTile.value == GAME_TILE_WINNING_SCORE) {
-      gb.win = true;
-    }
-  }
 }
 
 void moveOnGameboard(GameBoard &gb, point2D_t pt, point2D_t pt_offset) {

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -285,8 +285,7 @@ collasped_or_shifted_tilesOnGameboard(gameboard_data_array_t &gbda,
 }
 
 void discoverLargestTileValueOnGameboard(GameBoard gb, Tile targetTile) {
-  gb.largestTile =
-      gb.largestTile < targetTile.value ? targetTile.value : gb.largestTile;
+  gb.largestTile = std::max(gb.largestTile, targetTile.value);
 }
 
 void discoverWinningTileValueOnGameboard(GameBoard gb, Tile targetTile) {

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -77,7 +77,7 @@ int GameBoard::point2D_to_1D_index(point2D_t pt) const {
   return x + playsize * y;
 }
 
-std::vector<point2D_t> GameBoard::collectFreeTiles() const {
+std::vector<point2D_t> GameBoard::collectFreeTilesOnGameboard() const {
   std::vector<point2D_t> freeTiles;
   auto index_counter{0};
   const auto gatherFreePoint = [this, &freeTiles,
@@ -93,15 +93,15 @@ std::vector<point2D_t> GameBoard::collectFreeTiles() const {
   return freeTiles;
 }
 
-Tile GameBoard::getTile(point2D_t pt) const {
+Tile GameBoard::getTileOnGameboard(point2D_t pt) const {
   return board[point2D_to_1D_index(pt)];
 }
 
-void GameBoard::setTile(point2D_t pt, Tile tile) {
+void GameBoard::setTileOnGameboard(point2D_t pt, Tile tile) {
   board[point2D_to_1D_index(pt)] = tile;
 }
 
-ull GameBoard::getTileValue(point2D_t pt) const {
+ull GameBoard::getTileValueOnGameboard(point2D_t pt) const {
   return board[point2D_to_1D_index(pt)].value;
 }
 
@@ -109,7 +109,7 @@ void GameBoard::setTileValue(point2D_t pt, ull value) {
   board[point2D_to_1D_index(pt)].value = value;
 }
 
-bool GameBoard::getTileBlocked(point2D_t pt) const {
+bool GameBoard::getTileBlockedOnGameboard(point2D_t pt) const {
   return board[point2D_to_1D_index(pt)].blocked;
 }
 
@@ -152,7 +152,7 @@ bool GameBoard::canMove() {
           current_point - offset}; // Negative adjacent Check
       for (const auto current_offset : offset_check) {
         if (is_point_in_board_play_area(current_offset, getPlaySize())) {
-          return getTileValue(current_offset) == current_point_value;
+          return getTileValueOnGameboard(current_offset) == current_point_value;
         }
       }
       return false;
@@ -172,7 +172,7 @@ void GameBoard::registerMoveByOne() {
 
 bool GameBoard::addTile() {
   constexpr auto CHANCE_OF_VALUE_FOUR_OVER_TWO = 89; // Percentage
-  const auto freeTiles = collectFreeTiles();
+  const auto freeTiles = collectFreeTilesOnGameboard();
 
   if (!freeTiles.size()) {
     return true;
@@ -199,7 +199,7 @@ std::string GameBoard::drawSelf() const {
       const auto sp = (is_first_col ? "  " : " ");
       str_os << sp;
       str_os << "│ ";
-      str_os << drawTileString(getTile(point2D_t{x, y}));
+      str_os << drawTileString(getTileOnGameboard(point2D_t{x, y}));
     }
     str_os << " │";
     str_os << "\n";
@@ -209,38 +209,39 @@ std::string GameBoard::drawSelf() const {
   return str_os.str();
 }
 
-bool GameBoard::collaspeTiles(point2D_t pt, point2D_t pt_offset) {
-  Tile currentTile = getTile(pt);
-  Tile targetTile = getTile(pt + pt_offset);
+bool GameBoard::collaspeTilesOnGameboard(point2D_t pt, point2D_t pt_offset) {
+  Tile currentTile = getTileOnGameboard(pt);
+  Tile targetTile = getTileOnGameboard(pt + pt_offset);
 
   currentTile.value = 0;
   targetTile.value *= 2;
   score += targetTile.value;
   targetTile.blocked = true;
 
-  discoverLargestTileValue(targetTile);
-  discoverWinningTileValue(targetTile);
+  discoverLargestTileValueOnGameboard(targetTile);
+  discoverWinningTileValueOnGameboard(targetTile);
 
-  setTile(pt, currentTile);
-  setTile(pt + pt_offset, targetTile);
+  setTileOnGameboard(pt, currentTile);
+  setTileOnGameboard(pt + pt_offset, targetTile);
   return true;
 }
 
-bool GameBoard::shiftTiles(point2D_t pt, point2D_t pt_offset) {
-  Tile currentTile = getTile(pt);
-  Tile targetTile = getTile(pt + pt_offset);
+bool GameBoard::shiftTilesOnGameboard(point2D_t pt, point2D_t pt_offset) {
+  Tile currentTile = getTileOnGameboard(pt);
+  Tile targetTile = getTileOnGameboard(pt + pt_offset);
 
   targetTile.value = currentTile.value;
   currentTile.value = 0;
 
-  setTile(pt, currentTile);
-  setTile(pt + pt_offset, targetTile);
+  setTileOnGameboard(pt, currentTile);
+  setTileOnGameboard(pt + pt_offset, targetTile);
   return true;
 }
 
-bool GameBoard::collasped_or_shifted_tiles(point2D_t pt, point2D_t pt_offset) {
-  const auto currentTile = getTile(pt);
-  const auto targetTile = getTile(pt + pt_offset);
+bool GameBoard::collasped_or_shifted_tilesOnGameboard(point2D_t pt,
+                                                      point2D_t pt_offset) {
+  const auto currentTile = getTileOnGameboard(pt);
+  const auto targetTile = getTileOnGameboard(pt + pt_offset);
   const auto does_value_exist_in_target_point = targetTile.value;
   const auto is_value_same_as_target_value =
       (currentTile.value == targetTile.value);
@@ -251,18 +252,18 @@ bool GameBoard::collasped_or_shifted_tiles(point2D_t pt, point2D_t pt_offset) {
 
   if (does_value_exist_in_target_point && is_value_same_as_target_value &&
       no_tiles_are_blocked) {
-    return collaspeTiles(pt, pt_offset);
+    return collaspeTilesOnGameboard(pt, pt_offset);
   } else if (is_there_a_current_value_but_no_target_value) {
-    return shiftTiles(pt, pt_offset);
+    return shiftTilesOnGameboard(pt, pt_offset);
   }
   return false;
 }
 
-void GameBoard::discoverLargestTileValue(Tile targetTile) {
+void GameBoard::discoverLargestTileValueOnGameboard(Tile targetTile) {
   largestTile = largestTile < targetTile.value ? targetTile.value : largestTile;
 }
 
-void GameBoard::discoverWinningTileValue(Tile targetTile) {
+void GameBoard::discoverWinningTileValueOnGameboard(Tile targetTile) {
   if (!hasWon()) {
     constexpr auto GAME_TILE_WINNING_SCORE = 2048;
     if (targetTile.value == GAME_TILE_WINNING_SCORE) {
@@ -271,12 +272,12 @@ void GameBoard::discoverWinningTileValue(Tile targetTile) {
   }
 }
 
-void GameBoard::move(point2D_t pt, point2D_t pt_offset) {
-  if (collasped_or_shifted_tiles(pt, pt_offset)) {
+void GameBoard::moveOnGameboard(point2D_t pt, point2D_t pt_offset) {
+  if (collasped_or_shifted_tilesOnGameboard(pt, pt_offset)) {
     moved = true;
   }
   if (check_recursive_offset_in_game_bounds(pt, pt_offset, getPlaySize())) {
-    move(pt + pt_offset, pt_offset);
+    moveOnGameboard(pt + pt_offset, pt_offset);
   }
 }
 
@@ -285,8 +286,8 @@ void GameBoard::tumbleTilesUp() {
     int y = 1;
     while (y < getPlaySize()) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValue(current_point)) {
-        move(current_point, point2D_t{0, -1});
+      if (getTileValueOnGameboard(current_point)) {
+        moveOnGameboard(current_point, point2D_t{0, -1});
       }
       y++;
     }
@@ -298,8 +299,8 @@ void GameBoard::tumbleTilesDown() {
     int y = getPlaySize() - 2;
     while (y >= 0) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValue(current_point)) {
-        move(current_point, point2D_t{0, 1});
+      if (getTileValueOnGameboard(current_point)) {
+        moveOnGameboard(current_point, point2D_t{0, 1});
       }
       y--;
     }
@@ -311,8 +312,8 @@ void GameBoard::tumbleTilesLeft() {
     int x = 1;
     while (x < getPlaySize()) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValue(current_point)) {
-        move(current_point, {-1, 0});
+      if (getTileValueOnGameboard(current_point)) {
+        moveOnGameboard(current_point, {-1, 0});
       }
       x++;
     }
@@ -324,8 +325,8 @@ void GameBoard::tumbleTilesRight() {
     int x = getPlaySize() - 2;
     while (x >= 0) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValue(current_point)) {
-        move(current_point, point2D_t{1, 0});
+      if (getTileValueOnGameboard(current_point)) {
+        moveOnGameboard(current_point, point2D_t{1, 0});
       }
       x--;
     }
@@ -337,8 +338,8 @@ std::string GameBoard::printState() const {
   for (int y = 0; y < getPlaySize(); y++) {
     for (int x = 0; x < getPlaySize(); x++) {
       const auto current_point = point2D_t{x, y};
-      out_stream << getTileValue(current_point) << ":"
-                 << getTileBlocked(current_point) << ",";
+      out_stream << getTileValueOnGameboard(current_point) << ":"
+                 << getTileBlockedOnGameboard(current_point) << ",";
     }
     out_stream << "\n";
   }

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -314,23 +314,19 @@ collasped_or_shifted_tilesOnGameboardDataArray(gameboard_data_array_t gbda,
   return std::make_tuple(action_taken, COLLASPE_OR_SHIFT_T::ACTION_NONE);
 }
 
-void discoverLargestTileValueOnGameboard(GameBoard &gb, Tile targetTile) {
-  gb.largestTile = std::max(gb.largestTile, targetTile.value);
-}
+bool updateGameBoardStats(GameBoard &gb, ull target_tile_value) {
+  gb.score += target_tile_value;
 
-void discoverWinningTileValueOnGameboard(GameBoard &gb, Tile targetTile) {
+  //  Discover the largest tile value on the gameboard...
+  gb.largestTile = std::max(gb.largestTile, target_tile_value);
+
+  //  Discover the winning tile value on the gameboard...
   if (!hasWonOnGameboard(gb)) {
     constexpr auto GAME_TILE_WINNING_SCORE = 2048;
-    if (targetTile.value == GAME_TILE_WINNING_SCORE) {
+    if (target_tile_value == GAME_TILE_WINNING_SCORE) {
       gb.win = true;
     }
   }
-}
-
-bool updateGameBoardStats(GameBoard &gb, Tile targetTile) {
-  gb.score += targetTile.value;
-  discoverLargestTileValueOnGameboard(gb, targetTile);
-  discoverWinningTileValueOnGameboard(gb, targetTile);
   return true;
 }
 
@@ -345,7 +341,7 @@ void moveOnGameboard(GameBoard &gb, delta_t dt_point) {
       collaspeTilesOnGameboardDataArray(gb.gbda, dt_point);
       const auto targetTile = getTileOnGameboardDataArray(
           gb.gbda, dt_point.first + dt_point.second);
-      updateGameBoardStats(gb, targetTile);
+      updateGameBoardStats(gb, targetTile.value);
     }
     if (action_was_taken == COLLASPE_OR_SHIFT_T::ACTION_SHIFT) {
       shiftTilesOnGameboardDataArray(gb.gbda, dt_point);

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -285,11 +285,11 @@ collasped_or_shifted_tilesOnGameboard(gameboard_data_array_t gbda,
   return std::make_tuple(action_taken, COLLASPE_OR_SHIFT_T::ACTION_NONE);
 }
 
-void discoverLargestTileValueOnGameboard(GameBoard gb, Tile targetTile) {
+void discoverLargestTileValueOnGameboard(GameBoard &gb, Tile targetTile) {
   gb.largestTile = std::max(gb.largestTile, targetTile.value);
 }
 
-void discoverWinningTileValueOnGameboard(GameBoard gb, Tile targetTile) {
+void discoverWinningTileValueOnGameboard(GameBoard &gb, Tile targetTile) {
   if (!hasWonOnGameboard(gb)) {
     constexpr auto GAME_TILE_WINNING_SCORE = 2048;
     if (targetTile.value == GAME_TILE_WINNING_SCORE) {

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -5,6 +5,10 @@
 #include <sstream>
 
 namespace {
+
+// Pre-declare function signature for organisational reasons.
+Tile getTileOnGameboard(GameBoard gb, point2D_t pt);
+
 std::string drawTileString(Tile currentTile) {
   std::ostringstream tile_richtext;
   if (!currentTile.value) {
@@ -44,6 +48,30 @@ std::array<std::string, num_of_bars> make_patterned_bars(int playsize) {
   std::transform(std::begin(bar_pattern_list), std::end(bar_pattern_list),
                  std::begin(temp_bars), generate_x_bar_pattern);
   return temp_bars;
+}
+
+std::string drawSelf(GameBoard gb) {
+  enum { TOP_BAR, XN_BAR, BASE_BAR, MAX_TYPES_OF_BARS };
+  const auto vertibar =
+      make_patterned_bars<MAX_TYPES_OF_BARS>(getPlaySizeOfGameboard(gb));
+  std::ostringstream str_os;
+  for (int y = 0; y < getPlaySizeOfGameboard(gb); y++) {
+    const auto is_first_row = (y == 0);
+    str_os << (is_first_row ? std::get<TOP_BAR>(vertibar) :
+                              std::get<XN_BAR>(vertibar));
+    for (int x = 0; x < getPlaySizeOfGameboard(gb); x++) {
+      const auto is_first_col = (x == 0);
+      const auto sp = (is_first_col ? "  " : " ");
+      str_os << sp;
+      str_os << "│ ";
+      str_os << drawTileString(getTileOnGameboard(gb, point2D_t{x, y}));
+    }
+    str_os << " │";
+    str_os << "\n";
+  }
+  str_os << std::get<BASE_BAR>(vertibar);
+  str_os << "\n";
+  return str_os.str();
 }
 
 bool is_point_in_board_play_area(point2D_t pt, int playsize) {
@@ -258,30 +286,6 @@ bool GameBoard::addTile() {
   setTileValueOnGameboard(*this, randomFreeTile, value_four_or_two);
 
   return false;
-}
-
-std::string drawSelf(GameBoard gb) {
-  enum { TOP_BAR, XN_BAR, BASE_BAR, MAX_TYPES_OF_BARS };
-  const auto vertibar =
-      make_patterned_bars<MAX_TYPES_OF_BARS>(getPlaySizeOfGameboard(gb));
-  std::ostringstream str_os;
-  for (int y = 0; y < getPlaySizeOfGameboard(gb); y++) {
-    const auto is_first_row = (y == 0);
-    str_os << (is_first_row ? std::get<TOP_BAR>(vertibar) :
-                              std::get<XN_BAR>(vertibar));
-    for (int x = 0; x < getPlaySizeOfGameboard(gb); x++) {
-      const auto is_first_col = (x == 0);
-      const auto sp = (is_first_col ? "  " : " ");
-      str_os << sp;
-      str_os << "│ ";
-      str_os << drawTileString(getTileOnGameboard(gb, point2D_t{x, y}));
-    }
-    str_os << " │";
-    str_os << "\n";
-  }
-  str_os << std::get<BASE_BAR>(vertibar);
-  str_os << "\n";
-  return str_os.str();
 }
 
 void GameBoard::tumbleTilesUp() {

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -1,12 +1,31 @@
 #include "gameboard.hpp"
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <iomanip>
+#include <random>
 #include <sstream>
 
 namespace Game {
 
 namespace {
+
+class RandInt {
+public:
+  using clock = std::chrono::system_clock;
+  RandInt() : dist{0, std::numeric_limits<int>::max()} {
+    seed(clock::now().time_since_epoch().count());
+  }
+  RandInt(const int low, const int high) : dist{low, high} {
+    seed(clock::now().time_since_epoch().count());
+  }
+  int operator()() { return dist(re); }
+  void seed(const unsigned int s) { re.seed(s); }
+
+private:
+  std::minstd_rand re;
+  std::uniform_int_distribution<> dist;
+};
 
 std::string drawTileString(Tile currentTile) {
   std::ostringstream tile_richtext;

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -4,6 +4,8 @@
 #include <iomanip>
 #include <sstream>
 
+namespace Game {
+
 namespace {
 
 std::string drawTileString(Tile currentTile) {
@@ -378,6 +380,10 @@ void tumbleTilesRightOnGameboard(GameBoard &gb) {
 std::string printStateOfGameBoard(GameBoard gb) {
   return printStateOfGameBoardDataArray(gb.gbda);
 }
+
+} // namespace Game
+
+using namespace Game;
 
 std::ostream &operator<<(std::ostream &os, const GameBoard &gb) {
   return os << drawSelf(gb.gbda);

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <iomanip>
 #include <random>
 #include <sstream>
 
@@ -26,17 +25,6 @@ private:
   std::minstd_rand re;
   std::uniform_int_distribution<> dist;
 };
-
-std::string drawTileString(Tile currentTile) {
-  std::ostringstream tile_richtext;
-  if (!currentTile.value) {
-    tile_richtext << "    ";
-  } else {
-    tile_richtext << currentTile.tileColor(currentTile.value) << bold_on
-                  << std::setw(4) << currentTile.value << bold_off << def;
-  }
-  return tile_richtext.str();
-}
 
 int getPlaySizeOfGameboard(gameboard_data_array_t gbda) {
   return gbda.playsize;

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -27,34 +27,37 @@ private:
   std::uniform_int_distribution<> dist;
 };
 
-int getPlaySizeOfGameboard(gameboard_data_array_t gbda) {
+int getPlaySizeOfGameboardDataArray(gameboard_data_array_t gbda) {
   return gbda.playsize;
 }
 
 int point2D_to_1D_index(gameboard_data_array_t gbda, point2D_t pt) {
   int x, y;
   std::tie(x, y) = pt.get();
-  return x + getPlaySizeOfGameboard(gbda) * y;
+  return x + getPlaySizeOfGameboardDataArray(gbda) * y;
 }
 
-Tile getTileOnGameboard(gameboard_data_array_t gbda, point2D_t pt) {
+Tile getTileOnGameboardDataArray(gameboard_data_array_t gbda, point2D_t pt) {
   return gbda.board[point2D_to_1D_index(gbda, pt)];
 }
 
-void setTileOnGameboard(gameboard_data_array_t &gbda, point2D_t pt, Tile tile) {
+void setTileOnGameboardDataArray(gameboard_data_array_t &gbda, point2D_t pt,
+                                 Tile tile) {
   gbda.board[point2D_to_1D_index(gbda, pt)] = tile;
 }
 
-ull getTileValueOnGameboard(gameboard_data_array_t gbda, point2D_t pt) {
+ull getTileValueOnGameboardDataArray(gameboard_data_array_t gbda,
+                                     point2D_t pt) {
   return gbda.board[point2D_to_1D_index(gbda, pt)].value;
 }
 
-void setTileValueOnGameboard(gameboard_data_array_t &gbda, point2D_t pt,
-                             ull value) {
+void setTileValueOnGameboardDataArray(gameboard_data_array_t &gbda,
+                                      point2D_t pt, ull value) {
   gbda.board[point2D_to_1D_index(gbda, pt)].value = value;
 }
 
-bool getTileBlockedOnGameboard(gameboard_data_array_t gbda, point2D_t pt) {
+bool getTileBlockedOnGameboardDataArray(gameboard_data_array_t gbda,
+                                        point2D_t pt) {
   return gbda.board[point2D_to_1D_index(gbda, pt)].blocked;
 }
 
@@ -90,19 +93,20 @@ std::array<std::string, num_of_bars> make_patterned_bars(int playsize) {
 
 std::string drawSelf(gameboard_data_array_t gbda) {
   enum { TOP_BAR, XN_BAR, BASE_BAR, MAX_TYPES_OF_BARS };
-  const auto vertibar =
-      make_patterned_bars<MAX_TYPES_OF_BARS>(getPlaySizeOfGameboard(gbda));
+  const auto vertibar = make_patterned_bars<MAX_TYPES_OF_BARS>(
+      getPlaySizeOfGameboardDataArray(gbda));
   std::ostringstream str_os;
-  for (int y = 0; y < getPlaySizeOfGameboard(gbda); y++) {
+  for (int y = 0; y < getPlaySizeOfGameboardDataArray(gbda); y++) {
     const auto is_first_row = (y == 0);
     str_os << (is_first_row ? std::get<TOP_BAR>(vertibar) :
                               std::get<XN_BAR>(vertibar));
-    for (int x = 0; x < getPlaySizeOfGameboard(gbda); x++) {
+    for (int x = 0; x < getPlaySizeOfGameboardDataArray(gbda); x++) {
       const auto is_first_col = (x == 0);
       const auto sp = (is_first_col ? "  " : " ");
       str_os << sp;
       str_os << "│ ";
-      str_os << drawTileString(getTileOnGameboard(gbda, point2D_t{x, y}));
+      str_os << drawTileString(
+          getTileOnGameboardDataArray(gbda, point2D_t{x, y}));
     }
     str_os << " │";
     str_os << "\n";
@@ -114,11 +118,11 @@ std::string drawSelf(gameboard_data_array_t gbda) {
 
 std::string printStateOfGameBoardDataArray(gameboard_data_array_t gbda) {
   std::ostringstream os;
-  for (int y = 0; y < getPlaySizeOfGameboard(gbda); y++) {
-    for (int x = 0; x < getPlaySizeOfGameboard(gbda); x++) {
+  for (int y = 0; y < getPlaySizeOfGameboardDataArray(gbda); y++) {
+    for (int x = 0; x < getPlaySizeOfGameboardDataArray(gbda); x++) {
       const auto current_point = point2D_t{x, y};
-      os << getTileValueOnGameboard(gbda, current_point) << ":"
-         << getTileBlockedOnGameboard(gbda, current_point) << ",";
+      os << getTileValueOnGameboardDataArray(gbda, current_point) << ":"
+         << getTileBlockedOnGameboardDataArray(gbda, current_point) << ",";
     }
     os << "\n";
   }
@@ -162,8 +166,8 @@ bool canMoveOnGameboardDataArray(gameboard_data_array_t &gbda) {
 
   const auto can_move_to_offset = [=, &index_counter](const Tile t) {
     const auto current_point =
-        point2D_t{index_counter % getPlaySizeOfGameboard(gbda),
-                  index_counter / getPlaySizeOfGameboard(gbda)};
+        point2D_t{index_counter % getPlaySizeOfGameboardDataArray(gbda),
+                  index_counter / getPlaySizeOfGameboardDataArray(gbda)};
     index_counter++;
     const auto list_of_offsets = {point2D_t{1, 0}, point2D_t{0, 1}};
     const auto current_point_value = t.value;
@@ -173,9 +177,9 @@ bool canMoveOnGameboardDataArray(gameboard_data_array_t &gbda) {
           current_point + offset, // Positive adjacent check
           current_point - offset}; // Negative adjacent Check
       for (const auto current_offset : offset_check) {
-        if (is_point_in_board_play_area(current_offset,
-                                        getPlaySizeOfGameboard(gbda))) {
-          return getTileValueOnGameboard(gbda, current_offset) ==
+        if (is_point_in_board_play_area(
+                current_offset, getPlaySizeOfGameboardDataArray(gbda))) {
+          return getTileValueOnGameboardDataArray(gbda, current_offset) ==
                  current_point_value;
         }
       }
@@ -191,14 +195,14 @@ bool canMoveOnGameboardDataArray(gameboard_data_array_t &gbda) {
 }
 
 std::vector<point2D_t>
-collectFreeTilesOnGameboard(gameboard_data_array_t gbda) {
+collectFreeTilesOnGameboardDataArray(gameboard_data_array_t gbda) {
   std::vector<point2D_t> freeTiles;
   auto index_counter{0};
   const auto gatherFreePoint = [gbda, &freeTiles,
                                 &index_counter](const Tile t) {
     const auto current_point =
-        point2D_t{index_counter % getPlaySizeOfGameboard(gbda),
-                  index_counter / getPlaySizeOfGameboard(gbda)};
+        point2D_t{index_counter % getPlaySizeOfGameboardDataArray(gbda),
+                  index_counter / getPlaySizeOfGameboardDataArray(gbda)};
     if (!t.value) {
       freeTiles.push_back(current_point);
     }
@@ -210,7 +214,7 @@ collectFreeTilesOnGameboard(gameboard_data_array_t gbda) {
 
 bool addTileOnGameboardDataArray(gameboard_data_array_t &gbda) {
   constexpr auto CHANCE_OF_VALUE_FOUR_OVER_TWO = 89; // Percentage
-  const auto freeTiles = collectFreeTilesOnGameboard(gbda);
+  const auto freeTiles = collectFreeTilesOnGameboardDataArray(gbda);
 
   if (!freeTiles.size()) {
     return true;
@@ -219,33 +223,39 @@ bool addTileOnGameboardDataArray(gameboard_data_array_t &gbda) {
   const auto randomFreeTile = freeTiles.at(RandInt{}() % freeTiles.size());
   const auto value_four_or_two =
       RandInt{}() % 100 > CHANCE_OF_VALUE_FOUR_OVER_TWO ? 4 : 2;
-  setTileValueOnGameboard(gbda, randomFreeTile, value_four_or_two);
+  setTileValueOnGameboardDataArray(gbda, randomFreeTile, value_four_or_two);
 
   return false;
 }
 
-bool collaspeTilesOnGameboard(gameboard_data_array_t &gbda, delta_t dt_point) {
-  Tile currentTile = getTileOnGameboard(gbda, dt_point.first);
-  Tile targetTile = getTileOnGameboard(gbda, dt_point.first + dt_point.second);
+bool collaspeTilesOnGameboardDataArray(gameboard_data_array_t &gbda,
+                                       delta_t dt_point) {
+  Tile currentTile = getTileOnGameboardDataArray(gbda, dt_point.first);
+  Tile targetTile =
+      getTileOnGameboardDataArray(gbda, dt_point.first + dt_point.second);
 
   currentTile.value = 0;
   targetTile.value *= 2;
   targetTile.blocked = true;
 
-  setTileOnGameboard(gbda, dt_point.first, currentTile);
-  setTileOnGameboard(gbda, dt_point.first + dt_point.second, targetTile);
+  setTileOnGameboardDataArray(gbda, dt_point.first, currentTile);
+  setTileOnGameboardDataArray(gbda, dt_point.first + dt_point.second,
+                              targetTile);
   return true;
 }
 
-bool shiftTilesOnGameboard(gameboard_data_array_t &gbda, delta_t dt_point) {
-  Tile currentTile = getTileOnGameboard(gbda, dt_point.first);
-  Tile targetTile = getTileOnGameboard(gbda, dt_point.first + dt_point.second);
+bool shiftTilesOnGameboardDataArray(gameboard_data_array_t &gbda,
+                                    delta_t dt_point) {
+  Tile currentTile = getTileOnGameboardDataArray(gbda, dt_point.first);
+  Tile targetTile =
+      getTileOnGameboardDataArray(gbda, dt_point.first + dt_point.second);
 
   targetTile.value = currentTile.value;
   currentTile.value = 0;
 
-  setTileOnGameboard(gbda, dt_point.first, currentTile);
-  setTileOnGameboard(gbda, dt_point.first + dt_point.second, targetTile);
+  setTileOnGameboardDataArray(gbda, dt_point.first, currentTile);
+  setTileOnGameboardDataArray(gbda, dt_point.first + dt_point.second,
+                              targetTile);
   return true;
 }
 
@@ -259,11 +269,11 @@ enum class COLLASPE_OR_SHIFT_T {
 using bool_collaspe_shift_t = std::tuple<bool, COLLASPE_OR_SHIFT_T>;
 
 bool_collaspe_shift_t
-collasped_or_shifted_tilesOnGameboard(gameboard_data_array_t gbda,
-                                      delta_t dt_point) {
-  const auto currentTile = getTileOnGameboard(gbda, dt_point.first);
+collasped_or_shifted_tilesOnGameboardDataArray(gameboard_data_array_t gbda,
+                                               delta_t dt_point) {
+  const auto currentTile = getTileOnGameboardDataArray(gbda, dt_point.first);
   const auto targetTile =
-      getTileOnGameboard(gbda, dt_point.first + dt_point.second);
+      getTileOnGameboardDataArray(gbda, dt_point.first + dt_point.second);
   const auto does_value_exist_in_target_point = targetTile.value;
   const auto is_value_same_as_target_value =
       (currentTile.value == targetTile.value);
@@ -309,21 +319,21 @@ void moveOnGameboard(GameBoard &gb, delta_t dt_point) {
   auto did_gameboard_collaspe_or_shift_anything = bool{};
   auto action_was_taken = COLLASPE_OR_SHIFT_T::ACTION_NONE;
   std::tie(did_gameboard_collaspe_or_shift_anything, action_was_taken) =
-      collasped_or_shifted_tilesOnGameboard(gb.gbda, dt_point);
+      collasped_or_shifted_tilesOnGameboardDataArray(gb.gbda, dt_point);
   if (did_gameboard_collaspe_or_shift_anything) {
     gb.moved = true;
     if (action_was_taken == COLLASPE_OR_SHIFT_T::ACTION_COLLASPE) {
-      collaspeTilesOnGameboard(gb.gbda, dt_point);
-      const auto targetTile =
-          getTileOnGameboard(gb.gbda, dt_point.first + dt_point.second);
+      collaspeTilesOnGameboardDataArray(gb.gbda, dt_point);
+      const auto targetTile = getTileOnGameboardDataArray(
+          gb.gbda, dt_point.first + dt_point.second);
       updateGameBoardStats(gb, targetTile);
     }
     if (action_was_taken == COLLASPE_OR_SHIFT_T::ACTION_SHIFT) {
-      shiftTilesOnGameboard(gb.gbda, dt_point);
+      shiftTilesOnGameboardDataArray(gb.gbda, dt_point);
     }
   }
-  if (check_recursive_offset_in_game_bounds(dt_point,
-                                            getPlaySizeOfGameboard(gb.gbda))) {
+  if (check_recursive_offset_in_game_bounds(
+          dt_point, getPlaySizeOfGameboardDataArray(gb.gbda))) {
     moveOnGameboard(
         gb, std::make_pair(dt_point.first + dt_point.second, dt_point.second));
   }
@@ -357,11 +367,11 @@ bool addTileOnGameboard(GameBoard &gb) {
 }
 
 void tumbleTilesUpOnGameboard(GameBoard &gb) {
-  for (int x = 0; x < getPlaySizeOfGameboard(gb.gbda); x++) {
+  for (int x = 0; x < getPlaySizeOfGameboardDataArray(gb.gbda); x++) {
     int y = 1;
-    while (y < getPlaySizeOfGameboard(gb.gbda)) {
+    while (y < getPlaySizeOfGameboardDataArray(gb.gbda)) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboard(gb.gbda, current_point)) {
+      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
         moveOnGameboard(gb, std::make_pair(current_point, point2D_t{0, -1}));
       }
       y++;
@@ -370,11 +380,11 @@ void tumbleTilesUpOnGameboard(GameBoard &gb) {
 }
 
 void tumbleTilesDownOnGameboard(GameBoard &gb) {
-  for (int x = 0; x < getPlaySizeOfGameboard(gb.gbda); x++) {
-    int y = getPlaySizeOfGameboard(gb.gbda) - 2;
+  for (int x = 0; x < getPlaySizeOfGameboardDataArray(gb.gbda); x++) {
+    int y = getPlaySizeOfGameboardDataArray(gb.gbda) - 2;
     while (y >= 0) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboard(gb.gbda, current_point)) {
+      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
         moveOnGameboard(gb, std::make_pair(current_point, point2D_t{0, 1}));
       }
       y--;
@@ -383,11 +393,11 @@ void tumbleTilesDownOnGameboard(GameBoard &gb) {
 }
 
 void tumbleTilesLeftOnGameboard(GameBoard &gb) {
-  for (int y = 0; y < getPlaySizeOfGameboard(gb.gbda); y++) {
+  for (int y = 0; y < getPlaySizeOfGameboardDataArray(gb.gbda); y++) {
     int x = 1;
-    while (x < getPlaySizeOfGameboard(gb.gbda)) {
+    while (x < getPlaySizeOfGameboardDataArray(gb.gbda)) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboard(gb.gbda, current_point)) {
+      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
         moveOnGameboard(gb, std::make_pair(current_point, point2D_t{-1, 0}));
       }
       x++;
@@ -396,11 +406,11 @@ void tumbleTilesLeftOnGameboard(GameBoard &gb) {
 }
 
 void tumbleTilesRightOnGameboard(GameBoard &gb) {
-  for (int y = 0; y < getPlaySizeOfGameboard(gb.gbda); y++) {
-    int x = getPlaySizeOfGameboard(gb.gbda) - 2;
+  for (int y = 0; y < getPlaySizeOfGameboardDataArray(gb.gbda); y++) {
+    int x = getPlaySizeOfGameboardDataArray(gb.gbda) - 2;
     while (x >= 0) {
       const auto current_point = point2D_t{x, y};
-      if (getTileValueOnGameboard(gb.gbda, current_point)) {
+      if (getTileValueOnGameboardDataArray(gb.gbda, current_point)) {
         moveOnGameboard(gb, std::make_pair(current_point, point2D_t{1, 0}));
       }
       x--;

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -163,7 +163,7 @@ void unblockTilesOnGameboardDataArray(gameboard_data_array_t &gbda) {
                  });
 }
 
-bool canMoveOnGameboardDataArray(gameboard_data_array_t &gbda) {
+bool canMoveOnGameboardDataArray(gameboard_data_array_t gbda) {
   auto index_counter{0};
 
   const auto can_move_to_offset = [=, &index_counter](const Tile t) {

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -10,7 +10,7 @@ namespace Game {
 using tile_data_array_t = std::vector<Tile>;
 
 struct gameboard_data_array_t {
-  ull playsize{0};
+  size_t playsize{};
   tile_data_array_t board{};
 };
 

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -27,11 +27,13 @@ private:
 class GameBoard;
 using load_gameboard_status_t = std::tuple<bool, GameBoard>;
 
+using tile_data_array_t = std::vector<Tile>;
+
 class GameBoard {
   ull playsize{0};
 
 public:
-  std::vector<Tile> board;
+  tile_data_array_t board;
   bool win{};
   bool moved{true};
   ull score{};
@@ -40,8 +42,8 @@ public:
 
   GameBoard() = default;
   explicit GameBoard(ull playsize)
-      : playsize{playsize}, board{std::vector<Tile>(playsize * playsize)} {}
-  explicit GameBoard(ull playsize, const std::vector<Tile> &prempt_board)
+      : playsize{playsize}, board{tile_data_array_t(playsize * playsize)} {}
+  explicit GameBoard(ull playsize, const tile_data_array_t &prempt_board)
       : playsize{playsize}, board{prempt_board} {}
 
   friend int getPlaySizeOfGameboard(GameBoard gb);

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -1,7 +1,6 @@
 #ifndef GAMEBOARD_H
 #define GAMEBOARD_H
 
-#include "point2d.hpp"
 #include "tile.hpp"
 #include <tuple>
 #include <vector>

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -7,11 +7,10 @@
 
 namespace Game {
 
-using tile_data_array_t = std::vector<Tile>;
-
-using gameboard_data_array_t = std::tuple<size_t, tile_data_array_t>;
-
 struct GameBoard {
+  using tile_data_array_t = std::vector<Tile>;
+  using gameboard_data_array_t = std::tuple<size_t, tile_data_array_t>;
+
   gameboard_data_array_t gbda;
   bool win{};
   bool moved{true};
@@ -20,10 +19,8 @@ struct GameBoard {
   long long moveCount{-1};
 
   GameBoard() = default;
-  explicit GameBoard(ull playsize)
-      : gbda{playsize, tile_data_array_t(playsize * playsize)} {}
-  explicit GameBoard(ull playsize, const tile_data_array_t &prempt_board)
-      : gbda{playsize, prempt_board} {}
+  explicit GameBoard(ull playsize);
+  explicit GameBoard(ull playsize, tile_data_array_t prempt_board);
 };
 
 using load_gameboard_status_t = std::tuple<bool, GameBoard>;

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -24,9 +24,6 @@ private:
   std::uniform_int_distribution<> dist;
 };
 
-class GameBoard;
-using load_gameboard_status_t = std::tuple<bool, GameBoard>;
-
 using tile_data_array_t = std::vector<Tile>;
 
 struct gameboard_data_array_t {
@@ -34,11 +31,8 @@ struct gameboard_data_array_t {
   tile_data_array_t board{};
 };
 
-class GameBoard {
-
-public:
+struct GameBoard {
   gameboard_data_array_t gbda;
-
   bool win{};
   bool moved{true};
   ull score{};
@@ -66,6 +60,8 @@ public:
   friend void tumbleTilesLeftOnGameboard(GameBoard &gb);
   friend void tumbleTilesRightOnGameboard(GameBoard &gb);
 };
+
+using load_gameboard_status_t = std::tuple<bool, GameBoard>;
 
 std::ostream &operator<<(std::ostream &os, const GameBoard &gb);
 

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -47,6 +47,8 @@ public:
   friend int getPlaySizeOfGameboard(GameBoard gb);
   friend bool hasWonOnGameboard(GameBoard gb);
   friend long long MoveCountOnGameBoard(GameBoard gb);
+  friend std::string printStateOfGameBoard(GameBoard gb);
+
   void unblockTiles();
   bool canMove();
   void registerMoveByOne();
@@ -57,10 +59,8 @@ public:
   void tumbleTilesDown();
   void tumbleTilesLeft();
   void tumbleTilesRight();
-
-  friend std::string printStateOfGameBoard(GameBoard gb);
-  friend std::string drawSelf(GameBoard gb);
-  friend std::ostream &operator<<(std::ostream &os, const GameBoard &gb);
 };
+
+std::ostream &operator<<(std::ostream &os, const GameBoard &gb);
 
 #endif

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -44,9 +44,9 @@ public:
   explicit GameBoard(ull playsize, const std::vector<Tile> &prempt_board)
       : playsize{playsize}, board{prempt_board} {}
 
-  int getPlaySize() const;
-  bool hasWon() const;
-  long long MoveCount() const;
+  friend int getPlaySizeOfGameboard(GameBoard gb);
+  friend bool hasWonOnGameboard(GameBoard gb);
+  friend long long MoveCountOnGameBoard(GameBoard gb);
   void unblockTiles();
   bool canMove();
   void registerMoveByOne();
@@ -58,8 +58,8 @@ public:
   void tumbleTilesLeft();
   void tumbleTilesRight();
 
-  std::string printState() const;
-  std::string drawSelf() const;
+  friend std::string printStateOfGameBoard(GameBoard gb);
+  friend std::string drawSelf(GameBoard gb);
   friend std::ostream &operator<<(std::ostream &os, const GameBoard &gb);
 };
 

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -35,8 +35,10 @@ struct gameboard_data_array_t {
 };
 
 class GameBoard {
+
 public:
   gameboard_data_array_t gbda;
+
   bool win{};
   bool moved{true};
   ull score{};
@@ -49,7 +51,6 @@ public:
   explicit GameBoard(ull playsize, const tile_data_array_t &prempt_board)
       : gbda{playsize, prempt_board} {}
 
-  friend int getPlaySizeOfGameboard(GameBoard gb);
   friend bool hasWonOnGameboard(GameBoard gb);
   friend long long MoveCountOnGameBoard(GameBoard gb);
   friend std::string printStateOfGameBoard(GameBoard gb);

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -32,24 +32,28 @@ class GameBoard {
   std::vector<Tile> board;
   bool win{};
 
-  Tile getTileOnGameboard(point2D_t pt) const;
-  void setTileOnGameboard(point2D_t pt, Tile tile);
-  ull getTileValueOnGameboard(point2D_t pt) const;
-  bool getTileBlockedOnGameboard(point2D_t pt) const;
+  friend Tile getTileOnGameboard(GameBoard gb, point2D_t pt);
+  friend void setTileOnGameboard(GameBoard &gb, point2D_t pt, Tile tile);
+  friend ull getTileValueOnGameboard(GameBoard gb, point2D_t pt);
+  friend bool getTileBlockedOnGameboard(GameBoard gb, point2D_t pt);
 
-  int point2D_to_1D_index(point2D_t pt) const;
-  std::vector<point2D_t> collectFreeTilesOnGameboard() const;
+  friend std::vector<point2D_t> collectFreeTilesOnGameboard(GameBoard gb);
 
-  bool collaspeTilesOnGameboard(point2D_t pt, point2D_t pt_offset);
+  friend bool collaspeTilesOnGameboard(GameBoard &gb, point2D_t pt,
+                                       point2D_t pt_offset);
 
-  bool shiftTilesOnGameboard(point2D_t pt, point2D_t pt_offset);
+  friend bool shiftTilesOnGameboard(GameBoard &gb, point2D_t pt,
+                                    point2D_t pt_offset);
 
-  bool collasped_or_shifted_tilesOnGameboard(point2D_t pt, point2D_t pt_offset);
+  friend bool collasped_or_shifted_tilesOnGameboard(GameBoard &gb, point2D_t pt,
+                                                    point2D_t pt_offset);
 
-  void discoverLargestTileValueOnGameboard(Tile targetTile);
-  void discoverWinningTileValueOnGameboard(Tile targetTile);
+  friend void discoverLargestTileValueOnGameboard(GameBoard gb,
+                                                  Tile targetTile);
+  friend void discoverWinningTileValueOnGameboard(GameBoard gb,
+                                                  Tile targetTile);
 
-  void moveOnGameboard(point2D_t pt, point2D_t pt_offset);
+  friend void moveOnGameboard(GameBoard &gb, point2D_t pt, point2D_t pt_offset);
 
 public:
   bool moved{true};

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -32,24 +32,24 @@ class GameBoard {
   std::vector<Tile> board;
   bool win{};
 
-  Tile getTile(point2D_t pt) const;
-  void setTile(point2D_t pt, Tile tile);
-  ull getTileValue(point2D_t pt) const;
-  bool getTileBlocked(point2D_t pt) const;
+  Tile getTileOnGameboard(point2D_t pt) const;
+  void setTileOnGameboard(point2D_t pt, Tile tile);
+  ull getTileValueOnGameboard(point2D_t pt) const;
+  bool getTileBlockedOnGameboard(point2D_t pt) const;
 
   int point2D_to_1D_index(point2D_t pt) const;
-  std::vector<point2D_t> collectFreeTiles() const;
+  std::vector<point2D_t> collectFreeTilesOnGameboard() const;
 
-  bool collaspeTiles(point2D_t pt, point2D_t pt_offset);
+  bool collaspeTilesOnGameboard(point2D_t pt, point2D_t pt_offset);
 
-  bool shiftTiles(point2D_t pt, point2D_t pt_offset);
+  bool shiftTilesOnGameboard(point2D_t pt, point2D_t pt_offset);
 
-  bool collasped_or_shifted_tiles(point2D_t pt, point2D_t pt_offset);
+  bool collasped_or_shifted_tilesOnGameboard(point2D_t pt, point2D_t pt_offset);
 
-  void discoverLargestTileValue(Tile targetTile);
-  void discoverWinningTileValue(Tile targetTile);
+  void discoverLargestTileValueOnGameboard(Tile targetTile);
+  void discoverWinningTileValueOnGameboard(Tile targetTile);
 
-  void move(point2D_t pt, point2D_t pt_offset);
+  void moveOnGameboard(point2D_t pt, point2D_t pt_offset);
 
 public:
   bool moved{true};

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -35,7 +35,10 @@ class GameBoard {
   friend Tile getTileOnGameboard(GameBoard gb, point2D_t pt);
   friend void setTileOnGameboard(GameBoard &gb, point2D_t pt, Tile tile);
   friend ull getTileValueOnGameboard(GameBoard gb, point2D_t pt);
+  friend void setTileValueOnGameboard(GameBoard &gb, point2D_t pt, ull value);
   friend bool getTileBlockedOnGameboard(GameBoard gb, point2D_t pt);
+  friend void setTileBlockedOnGameboard(GameBoard &gb, point2D_t pt,
+                                        bool blocked);
 
   friend std::vector<point2D_t> collectFreeTilesOnGameboard(GameBoard gb);
 
@@ -67,8 +70,6 @@ public:
   explicit GameBoard(ull playsize, const std::vector<Tile> &prempt_board)
       : playsize{playsize}, board{prempt_board} {}
 
-  void setTileValue(point2D_t pt, ull value);
-  void setTileBlocked(point2D_t pt, bool blocked);
   int getPlaySize() const;
   bool hasWon() const;
   long long MoveCount() const;

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -44,24 +44,24 @@ struct GameBoard {
       : gbda{playsize, tile_data_array_t(playsize * playsize)} {}
   explicit GameBoard(ull playsize, const tile_data_array_t &prempt_board)
       : gbda{playsize, prempt_board} {}
-
-  friend bool hasWonOnGameboard(GameBoard gb);
-  friend long long MoveCountOnGameBoard(GameBoard gb);
-  friend std::string printStateOfGameBoard(GameBoard gb);
-
-  friend void unblockTilesOnGameboard(GameBoard &gb);
-  friend bool canMoveOnGameboard(GameBoard &gb);
-  friend void registerMoveByOneOnGameboard(GameBoard &gb);
-
-  friend bool addTileOnGameboard(GameBoard &gb);
-
-  friend void tumbleTilesUpOnGameboard(GameBoard &gb);
-  friend void tumbleTilesDownOnGameboard(GameBoard &gb);
-  friend void tumbleTilesLeftOnGameboard(GameBoard &gb);
-  friend void tumbleTilesRightOnGameboard(GameBoard &gb);
 };
 
 using load_gameboard_status_t = std::tuple<bool, GameBoard>;
+
+bool hasWonOnGameboard(GameBoard gb);
+long long MoveCountOnGameBoard(GameBoard gb);
+
+void unblockTilesOnGameboard(GameBoard &gb);
+bool canMoveOnGameboard(GameBoard &gb);
+bool addTileOnGameboard(GameBoard &gb);
+void registerMoveByOneOnGameboard(GameBoard &gb);
+
+void tumbleTilesUpOnGameboard(GameBoard &gb);
+void tumbleTilesDownOnGameboard(GameBoard &gb);
+void tumbleTilesLeftOnGameboard(GameBoard &gb);
+void tumbleTilesRightOnGameboard(GameBoard &gb);
+
+std::string printStateOfGameBoard(GameBoard gb);
 
 std::ostream &operator<<(std::ostream &os, const GameBoard &gb);
 

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -29,11 +29,14 @@ using load_gameboard_status_t = std::tuple<bool, GameBoard>;
 
 using tile_data_array_t = std::vector<Tile>;
 
-class GameBoard {
+struct gameboard_data_array_t {
   ull playsize{0};
+  tile_data_array_t board{};
+};
 
+class GameBoard {
 public:
-  tile_data_array_t board;
+  gameboard_data_array_t gbda;
   bool win{};
   bool moved{true};
   ull score{};
@@ -42,9 +45,9 @@ public:
 
   GameBoard() = default;
   explicit GameBoard(ull playsize)
-      : playsize{playsize}, board{tile_data_array_t(playsize * playsize)} {}
+      : gbda{playsize, tile_data_array_t(playsize * playsize)} {}
   explicit GameBoard(ull playsize, const tile_data_array_t &prempt_board)
-      : playsize{playsize}, board{prempt_board} {}
+      : gbda{playsize, prempt_board} {}
 
   friend int getPlaySizeOfGameboard(GameBoard gb);
   friend bool hasWonOnGameboard(GameBoard gb);

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -29,36 +29,10 @@ using load_gameboard_status_t = std::tuple<bool, GameBoard>;
 
 class GameBoard {
   ull playsize{0};
-  std::vector<Tile> board;
-  bool win{};
-
-  friend Tile getTileOnGameboard(GameBoard gb, point2D_t pt);
-  friend void setTileOnGameboard(GameBoard &gb, point2D_t pt, Tile tile);
-  friend ull getTileValueOnGameboard(GameBoard gb, point2D_t pt);
-  friend void setTileValueOnGameboard(GameBoard &gb, point2D_t pt, ull value);
-  friend bool getTileBlockedOnGameboard(GameBoard gb, point2D_t pt);
-  friend void setTileBlockedOnGameboard(GameBoard &gb, point2D_t pt,
-                                        bool blocked);
-
-  friend std::vector<point2D_t> collectFreeTilesOnGameboard(GameBoard gb);
-
-  friend bool collaspeTilesOnGameboard(GameBoard &gb, point2D_t pt,
-                                       point2D_t pt_offset);
-
-  friend bool shiftTilesOnGameboard(GameBoard &gb, point2D_t pt,
-                                    point2D_t pt_offset);
-
-  friend bool collasped_or_shifted_tilesOnGameboard(GameBoard &gb, point2D_t pt,
-                                                    point2D_t pt_offset);
-
-  friend void discoverLargestTileValueOnGameboard(GameBoard gb,
-                                                  Tile targetTile);
-  friend void discoverWinningTileValueOnGameboard(GameBoard gb,
-                                                  Tile targetTile);
-
-  friend void moveOnGameboard(GameBoard &gb, point2D_t pt, point2D_t pt_offset);
 
 public:
+  std::vector<Tile> board;
+  bool win{};
   bool moved{true};
   ull score{};
   ull largestTile{2};

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -9,10 +9,7 @@ namespace Game {
 
 using tile_data_array_t = std::vector<Tile>;
 
-struct gameboard_data_array_t {
-  size_t playsize{};
-  tile_data_array_t board{};
-};
+using gameboard_data_array_t = std::tuple<size_t, tile_data_array_t>;
 
 struct GameBoard {
   gameboard_data_array_t gbda;

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -3,28 +3,10 @@
 
 #include "point2d.hpp"
 #include "tile.hpp"
-#include <chrono>
-#include <random>
 #include <tuple>
+#include <vector>
 
 namespace Game {
-
-class RandInt {
-public:
-  using clock = std::chrono::system_clock;
-  RandInt() : dist{0, std::numeric_limits<int>::max()} {
-    seed(clock::now().time_since_epoch().count());
-  }
-  RandInt(const int low, const int high) : dist{low, high} {
-    seed(clock::now().time_since_epoch().count());
-  }
-  int operator()() { return dist(re); }
-  void seed(const unsigned int s) { re.seed(s); }
-
-private:
-  std::minstd_rand re;
-  std::uniform_int_distribution<> dist;
-};
 
 using tile_data_array_t = std::vector<Tile>;
 

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -49,16 +49,16 @@ public:
   friend long long MoveCountOnGameBoard(GameBoard gb);
   friend std::string printStateOfGameBoard(GameBoard gb);
 
-  void unblockTiles();
-  bool canMove();
-  void registerMoveByOne();
+  friend void unblockTilesOnGameboard(GameBoard &gb);
+  friend bool canMoveOnGameboard(GameBoard &gb);
+  friend void registerMoveByOneOnGameboard(GameBoard &gb);
 
-  bool addTile();
+  friend bool addTileOnGameboard(GameBoard &gb);
 
-  void tumbleTilesUp();
-  void tumbleTilesDown();
-  void tumbleTilesLeft();
-  void tumbleTilesRight();
+  friend void tumbleTilesUpOnGameboard(GameBoard &gb);
+  friend void tumbleTilesDownOnGameboard(GameBoard &gb);
+  friend void tumbleTilesLeftOnGameboard(GameBoard &gb);
+  friend void tumbleTilesRightOnGameboard(GameBoard &gb);
 };
 
 std::ostream &operator<<(std::ostream &os, const GameBoard &gb);

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -7,6 +7,8 @@
 #include <random>
 #include <tuple>
 
+namespace Game {
+
 class RandInt {
 public:
   using clock = std::chrono::system_clock;
@@ -63,6 +65,8 @@ void tumbleTilesRightOnGameboard(GameBoard &gb);
 
 std::string printStateOfGameBoard(GameBoard gb);
 
-std::ostream &operator<<(std::ostream &os, const GameBoard &gb);
+} // namespace Game
+
+std::ostream &operator<<(std::ostream &os, const Game::GameBoard &gb);
 
 #endif

--- a/src/headers/tile.hpp
+++ b/src/headers/tile.hpp
@@ -13,4 +13,6 @@ public:
   Color::Modifier tileColor(ull);
 };
 
+std::string drawTileString(Tile currentTile);
+
 #endif

--- a/src/saveresource.cpp
+++ b/src/saveresource.cpp
@@ -8,13 +8,13 @@ namespace {
 
 bool generateFilefromPreviousGameStatisticsData(std::ostream &os,
                                                 const GameBoard &gb) {
-  os << gb.score << ":" << gb.MoveCount();
+  os << gb.score << ":" << MoveCountOnGameBoard(gb);
   return true;
 }
 
 bool generateFilefromPreviousGameStateData(std::ostream &os,
                                            const GameBoard &gb) {
-  os << gb.printState();
+  os << printStateOfGameBoard(gb);
   return true;
 }
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1,5 +1,7 @@
 #include "tile.hpp"
 #include <cmath>
+#include <iomanip>
+#include <sstream>
 #include <vector>
 
 Color::Modifier Tile::tileColor(ull value) {
@@ -9,4 +11,15 @@ Color::Modifier Tile::tileColor(ull value) {
   int index = log < 12 ? log - 1 : 10;
 
   return colors[index];
+}
+
+std::string drawTileString(Tile currentTile) {
+  std::ostringstream tile_richtext;
+  if (!currentTile.value) {
+    tile_richtext << "    ";
+  } else {
+    tile_richtext << currentTile.tileColor(currentTile.value) << bold_on
+                  << std::setw(4) << currentTile.value << bold_off << def;
+  }
+  return tile_richtext.str();
 }


### PR DESCRIPTION
Continuing the trend from PR #102...
_This is a large PR so pushing the changes as it is mostly complete._

* Makes the `Gameboard` class into a _simple `struct` datatype_. (Check out the `gameboard.hpp` header file!)
* Converts (nearly all) member functions of `Gameboard` class into _free-standing functions_.
* Many free-standing functions now in _anonymous namespace_.
* `Gameboard` struct is in `Game` namespace.
* Renamed function names to be more understandable.
* Added more _"strong" datatypes_ to function parameters.
* Function parameters' required datatypes are now more _"local"_ to its translation unit declarations.
* Moved some out-of-place functions to other more appropriate translation units.

