### PR TITLE
Fix: Convert Tile class to a simple struct datatype

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,4 +1,5 @@
 #include "game.hpp"
+#include "color.hpp"
 #include "game-graphics.hpp"
 #include "game-input.hpp"
 #include "game-pregamemenu.hpp"

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -42,20 +42,20 @@ struct gameboard_data_point_t {
     return x + getPlaySizeOfGameboardDataArray(gbda) * y;
   }
 
-  Tile operator()(gameboard_data_array_t gbda, point2D_t pt) const {
+  tile_t operator()(gameboard_data_array_t gbda, point2D_t pt) const {
     return std::get<IDX_BOARD>(gbda)[point2D_to_1D_index(gbda, pt)];
   }
-  Tile &operator()(gameboard_data_array_t &gbda, point2D_t pt) {
+  tile_t &operator()(gameboard_data_array_t &gbda, point2D_t pt) {
     return std::get<IDX_BOARD>(gbda)[point2D_to_1D_index(gbda, pt)];
   }
 };
 
-Tile getTileOnGameboardDataArray(gameboard_data_array_t gbda, point2D_t pt) {
+tile_t getTileOnGameboardDataArray(gameboard_data_array_t gbda, point2D_t pt) {
   return gameboard_data_point_t{}(gbda, pt);
 }
 
 void setTileOnGameboardDataArray(gameboard_data_array_t &gbda, point2D_t pt,
-                                 Tile tile) {
+                                 tile_t tile) {
   gameboard_data_point_t{}(gbda, pt) = tile;
 }
 
@@ -175,8 +175,8 @@ unblockTilesOnGameboardDataArray(gameboard_data_array_t gbda) {
       tile_data_array_t(std::get<IDX_BOARD>(gbda).size());
   std::transform(std::begin(std::get<IDX_BOARD>(gbda)),
                  std::end(std::get<IDX_BOARD>(gbda)),
-                 std::begin(new_board_data_array), [](const Tile t) {
-                   return Tile{t.value, false};
+                 std::begin(new_board_data_array), [](const tile_t t) {
+                   return tile_t{t.value, false};
                  });
   return gameboard_data_array_t{std::get<IDX_PLAYSIZE>(gbda),
                                 new_board_data_array};
@@ -185,7 +185,7 @@ unblockTilesOnGameboardDataArray(gameboard_data_array_t gbda) {
 bool canMoveOnGameboardDataArray(gameboard_data_array_t gbda) {
   auto index_counter{0};
 
-  const auto can_move_to_offset = [=, &index_counter](const Tile t) {
+  const auto can_move_to_offset = [=, &index_counter](const tile_t t) {
     const int playsize = getPlaySizeOfGameboardDataArray(gbda);
     const auto current_point =
         point2D_t{index_counter % playsize, index_counter / playsize};
@@ -251,8 +251,8 @@ bool addTileOnGameboardDataArray(gameboard_data_array_t &gbda) {
 
 bool collaspeTilesOnGameboardDataArray(gameboard_data_array_t &gbda,
                                        delta_t dt_point) {
-  Tile currentTile = getTileOnGameboardDataArray(gbda, dt_point.first);
-  Tile targetTile =
+  tile_t currentTile = getTileOnGameboardDataArray(gbda, dt_point.first);
+  tile_t targetTile =
       getTileOnGameboardDataArray(gbda, dt_point.first + dt_point.second);
 
   currentTile.value = 0;
@@ -267,8 +267,8 @@ bool collaspeTilesOnGameboardDataArray(gameboard_data_array_t &gbda,
 
 bool shiftTilesOnGameboardDataArray(gameboard_data_array_t &gbda,
                                     delta_t dt_point) {
-  Tile currentTile = getTileOnGameboardDataArray(gbda, dt_point.first);
-  Tile targetTile =
+  tile_t currentTile = getTileOnGameboardDataArray(gbda, dt_point.first);
+  tile_t targetTile =
       getTileOnGameboardDataArray(gbda, dt_point.first + dt_point.second);
 
   targetTile.value = currentTile.value;

--- a/src/gameboard.cpp
+++ b/src/gameboard.cpp
@@ -118,8 +118,7 @@ std::string drawSelf(gameboard_data_array_t gbda) {
       const auto sp = (is_first_col ? "  " : " ");
       str_os << sp;
       str_os << "│ ";
-      str_os << drawTileString(
-          getTileOnGameboardDataArray(gbda, point2D_t{x, y}));
+      str_os << getTileOnGameboardDataArray(gbda, point2D_t{x, y});
     }
     str_os << " │";
     str_os << "\n";

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -8,7 +8,7 @@
 namespace Game {
 
 struct GameBoard {
-  using tile_data_array_t = std::vector<Tile>;
+  using tile_data_array_t = std::vector<tile_t>;
   using gameboard_data_array_t = std::tuple<size_t, tile_data_array_t>;
 
   gameboard_data_array_t gbda;

--- a/src/headers/tile.hpp
+++ b/src/headers/tile.hpp
@@ -4,11 +4,15 @@
 #include "color.hpp"
 #include "global.hpp"
 
+namespace Game {
+
 struct tile_t {
   ull value{};
   bool blocked{};
 };
 
-std::ostream &operator<<(std::ostream &os, const tile_t &t);
+} // namespace Game
+
+std::ostream &operator<<(std::ostream &os, const Game::tile_t &t);
 
 #endif

--- a/src/headers/tile.hpp
+++ b/src/headers/tile.hpp
@@ -1,7 +1,6 @@
 #ifndef TILE_H
 #define TILE_H
 
-#include "color.hpp"
 #include "global.hpp"
 
 namespace Game {

--- a/src/headers/tile.hpp
+++ b/src/headers/tile.hpp
@@ -9,6 +9,6 @@ struct tile_t {
   bool blocked{};
 };
 
-std::string drawTileString(tile_t currentTile);
+std::ostream &operator<<(std::ostream &os, const tile_t &t);
 
 #endif

--- a/src/headers/tile.hpp
+++ b/src/headers/tile.hpp
@@ -4,11 +4,11 @@
 #include "color.hpp"
 #include "global.hpp"
 
-struct Tile {
+struct tile_t {
   ull value{};
   bool blocked{};
 };
 
-std::string drawTileString(Tile currentTile);
+std::string drawTileString(tile_t currentTile);
 
 #endif

--- a/src/headers/tile.hpp
+++ b/src/headers/tile.hpp
@@ -4,13 +4,9 @@
 #include "color.hpp"
 #include "global.hpp"
 
-class Tile {
-public:
-  Tile() = default;
-  explicit Tile(ull value, bool blocked) : value{value}, blocked{blocked} {}
-  ull value{0};
-  bool blocked{false};
-  Color::Modifier tileColor(ull);
+struct Tile {
+  ull value{};
+  bool blocked{};
 };
 
 std::string drawTileString(Tile currentTile);

--- a/src/loadresource.cpp
+++ b/src/loadresource.cpp
@@ -37,8 +37,9 @@ std::vector<std::string> get_file_tile_data(std::istream &buf) {
   return tempbuffer;
 }
 
-std::vector<Tile> process_file_tile_string_data(std::vector<std::string> buf) {
-  std::vector<Tile> result_buf;
+std::vector<tile_t>
+process_file_tile_string_data(std::vector<std::string> buf) {
+  std::vector<tile_t> result_buf;
   auto tile_processed_counter{0};
   const auto prime_tile_data =
       [&tile_processed_counter](const std::string tile_data) {
@@ -67,7 +68,7 @@ std::vector<Tile> process_file_tile_string_data(std::vector<std::string> buf) {
         const unsigned long long tile_value =
             std::get<IDX_TILE_VALUE>(tile_internal);
         const bool tile_blocked = std::get<IDX_TILE_BLOCKED>(tile_internal);
-        return Tile{tile_value, tile_blocked};
+        return tile_t{tile_value, tile_blocked};
       };
   std::transform(std::begin(buf), std::end(buf), std::back_inserter(result_buf),
                  prime_tile_data);

--- a/src/loadresource.cpp
+++ b/src/loadresource.cpp
@@ -64,8 +64,10 @@ std::vector<Tile> process_file_tile_string_data(std::vector<std::string> buf) {
           }
         }
         tile_processed_counter++;
-        return Tile(std::get<IDX_TILE_VALUE>(tile_internal),
-                    std::get<IDX_TILE_BLOCKED>(tile_internal));
+        const unsigned long long tile_value =
+            std::get<IDX_TILE_VALUE>(tile_internal);
+        const bool tile_blocked = std::get<IDX_TILE_BLOCKED>(tile_internal);
+        return Tile{tile_value, tile_blocked};
       };
   std::transform(std::begin(buf), std::end(buf), std::back_inserter(result_buf),
                  prime_tile_data);

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -15,8 +15,6 @@ Color::Modifier tileColor(ull value) {
   return colors[index];
 }
 
-} // namespace
-
 std::string drawTileString(tile_t currentTile) {
   std::ostringstream tile_richtext;
   if (!currentTile.value) {
@@ -26,4 +24,10 @@ std::string drawTileString(tile_t currentTile) {
                   << currentTile.value << bold_off << def;
   }
   return tile_richtext.str();
+}
+
+} // namespace
+
+std::ostream &operator<<(std::ostream &os, const tile_t &t) {
+  return os << drawTileString(t);
 }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -4,7 +4,9 @@
 #include <sstream>
 #include <vector>
 
-Color::Modifier Tile::tileColor(ull value) {
+namespace {
+
+Color::Modifier tileColor(ull value) {
   std::vector<Color::Modifier> colors{red, yellow, magenta, blue, cyan, yellow,
                                       red, yellow, magenta, blue, green};
   int log = log2(value);
@@ -13,13 +15,15 @@ Color::Modifier Tile::tileColor(ull value) {
   return colors[index];
 }
 
+} // namespace
+
 std::string drawTileString(Tile currentTile) {
   std::ostringstream tile_richtext;
   if (!currentTile.value) {
     tile_richtext << "    ";
   } else {
-    tile_richtext << currentTile.tileColor(currentTile.value) << bold_on
-                  << std::setw(4) << currentTile.value << bold_off << def;
+    tile_richtext << tileColor(currentTile.value) << bold_on << std::setw(4)
+                  << currentTile.value << bold_off << def;
   }
   return tile_richtext.str();
 }

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1,4 +1,5 @@
 #include "tile.hpp"
+#include "color.hpp"
 #include <cmath>
 #include <iomanip>
 #include <sstream>

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -4,6 +4,8 @@
 #include <sstream>
 #include <vector>
 
+namespace Game {
+
 namespace {
 
 Color::Modifier tileColor(ull value) {
@@ -27,6 +29,10 @@ std::string drawTileString(tile_t currentTile) {
 }
 
 } // namespace
+
+} // namespace Game
+
+using namespace Game;
 
 std::ostream &operator<<(std::ostream &os, const tile_t &t) {
   return os << drawTileString(t);

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -17,7 +17,7 @@ Color::Modifier tileColor(ull value) {
 
 } // namespace
 
-std::string drawTileString(Tile currentTile) {
+std::string drawTileString(tile_t currentTile) {
   std::ostringstream tile_richtext;
   if (!currentTile.value) {
     tile_richtext << "    ";


### PR DESCRIPTION
* _Removes_ some unneeded member functions.
* Wraps some functions into the _anonymous namespace_ of translation unit.
* Cleans up some `#include` definitions.