### PR TITLE
Fix: Forward declare GameBoard class in certain header files

### DIFF
--- a/src/headers/game.hpp
+++ b/src/headers/game.hpp
@@ -1,9 +1,8 @@
 #ifndef GAME_H
 #define GAME_H
 
-#include "gameboard.hpp"
-
 namespace Game {
+struct GameBoard;
 
 enum class PlayGameFlag { BrandNewGame, ContinuePreviousGame };
 void playGame(PlayGameFlag cont, GameBoard gb,

--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -23,8 +23,6 @@ struct GameBoard {
   explicit GameBoard(ull playsize, tile_data_array_t prempt_board);
 };
 
-using load_gameboard_status_t = std::tuple<bool, GameBoard>;
-
 bool hasWonOnGameboard(GameBoard gb);
 long long MoveCountOnGameBoard(GameBoard gb);
 

--- a/src/headers/loadresource.hpp
+++ b/src/headers/loadresource.hpp
@@ -1,13 +1,13 @@
 #ifndef LOADRESOURCE_H
 #define LOADRESOURCE_H
 
-#include "gameboard.hpp"
 #include <string>
 #include <tuple>
 
 namespace Game {
-namespace Loader {
+using load_gameboard_status_t = std::tuple<bool, struct GameBoard>;
 
+namespace Loader {
 load_gameboard_status_t load_GameBoard_data_from_file(std::string filename);
 
 // Output: {[loadfile_ok_status], [decltype(gameboard.score)],

--- a/src/headers/saveresource.hpp
+++ b/src/headers/saveresource.hpp
@@ -1,11 +1,12 @@
 #ifndef SAVERESOURCE_H
 #define SAVERESOURCE_H
 
-#include "gameboard.hpp"
 #include <string>
 #include <tuple>
 
 namespace Game {
+struct GameBoard;
+
 namespace Saver {
 void saveToFilePreviousGameStateData(std::string filename, const GameBoard &gb);
 void saveToFilePreviousGameStatisticsData(std::string filename,


### PR DESCRIPTION
Adding certain #includes in header files can pull dependencies not needed in certain translation units.
By forward declaring the classes needed (in the header files), translation units can further #include what is required to complete a class definition, keeping definitions more local to their TU's scope.