### PR TITLE
Fix: Refactored various items in Game TU

### DIFF
--- a/src/game-graphics.cpp
+++ b/src/game-graphics.cpp
@@ -25,25 +25,6 @@ std::string AsciiArt2048() {
   return title_card_richtext.str();
 }
 
-std::string MessageScoreSavedPrompt() {
-  constexpr auto score_saved_text = "Score saved!";
-  constexpr auto sp = "  ";
-  std::ostringstream score_saved_richtext;
-  score_saved_richtext << "\n"
-                       << green << bold_on << sp << score_saved_text << bold_off
-                       << def << "\n";
-  return score_saved_richtext.str();
-}
-
-std::string AskForPlayerNamePrompt() {
-  constexpr auto score_prompt_text =
-      "Please enter your name to save this score: ";
-  constexpr auto sp = "  ";
-  std::ostringstream score_prompt_richtext;
-  score_prompt_richtext << bold_on << sp << score_prompt_text << bold_off;
-  return score_prompt_richtext.str();
-}
-
 std::string BoardInputPrompt() {
   const auto board_size_prompt_text = {
       "(NOTE: Scores and statistics will be saved only for the 4x4 gameboard)\n",
@@ -166,49 +147,6 @@ std::string InputCommandListFooterPrompt() {
   for (const auto txt : input_commands_list_footer_text) {
     str_os << sp << txt << "\n";
   }
-  return str_os.str();
-}
-
-std::string EndGameStatisticsPrompt(finalscore_display_data_t finalscore) {
-  std::ostringstream str_os;
-  constexpr auto stats_title_text = "STATISTICS";
-  constexpr auto divider_text = "──────────";
-  constexpr auto sp = "  ";
-  const auto stats_attributes_text = {
-      "Final score:", "Largest Tile:", "Number of moves:", "Time taken:"};
-  enum FinalScoreDisplayDataFields {
-    IDX_FINAL_SCORE_VALUE,
-    IDX_LARGEST_TILE,
-    IDX_MOVE_COUNT,
-    IDX_DURATION,
-    MAX_NUM_OF_FINALSCOREDISPLAYDATA_INDEXES
-  };
-  const auto data_stats =
-      std::array<std::string, MAX_NUM_OF_FINALSCOREDISPLAYDATA_INDEXES>{
-          std::get<IDX_FINAL_SCORE_VALUE>(finalscore),
-          std::get<IDX_LARGEST_TILE>(finalscore),
-          std::get<IDX_MOVE_COUNT>(finalscore),
-          std::get<IDX_DURATION>(finalscore)};
-
-  std::ostringstream stats_richtext;
-  stats_richtext << yellow << sp << stats_title_text << def << "\n";
-  stats_richtext << yellow << sp << divider_text << def << "\n";
-
-  auto counter{0};
-  const auto populate_stats_info = [data_stats, stats_attributes_text, &counter,
-                                    &stats_richtext](const std::string) {
-    stats_richtext << sp << std::left << std::setw(19)
-                   << std::begin(stats_attributes_text)[counter] << bold_on
-                   << std::begin(data_stats)[counter] << bold_off << "\n";
-    counter++;
-  };
-
-  for (const auto s : stats_attributes_text) {
-    populate_stats_info(s);
-  }
-
-  str_os << stats_richtext.str();
-  str_os << "\n\n";
   return str_os.str();
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -228,18 +228,6 @@ bool continue_playing_game(std::istream &in_os) {
   return true;
 }
 
-void saveGamePlayState() {
-  using namespace Saver;
-  // Currently two datafiles for now.
-  // Will be merged into one datafile in a future PR.
-  std::remove("../data/previousGame");
-  std::remove("../data/previousGameStats");
-
-  saveToFilePreviousGameStateData("../data/previousGame", gamePlayBoard);
-  saveToFilePreviousGameStatisticsData("../data/previousGameStats",
-                                       gamePlayBoard);
-}
-
 wrapper_bool_gamestatus_t process_gameStatus(gamestatus_t gamestatus) {
   auto loop_again{true};
   if (!gamestatus[FLAG_ENDLESS_MODE]) {
@@ -258,7 +246,7 @@ wrapper_bool_gamestatus_t process_gameStatus(gamestatus_t gamestatus) {
     loop_again = false;
   }
   if (gamestatus[FLAG_SAVED_GAME]) {
-    saveGamePlayState();
+    Saver::saveGamePlayState(gamePlayBoard);
   }
 
   // New loop cycle: reset question asking event trigger

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -161,8 +161,8 @@ gamestatus_t update_one_shot_display_flags(gamestatus_t gamestatus) {
   return gamestatus;
 }
 
-using wrapper_bool_gamestatus_t = std::tuple<bool, gamestatus_t>;
-wrapper_bool_gamestatus_t check_input_other(char c, gamestatus_t gamestatus) {
+using bool_gamestatus_t = std::tuple<bool, gamestatus_t>;
+bool_gamestatus_t check_input_other(char c, gamestatus_t gamestatus) {
   using namespace Input::Keypress::Code;
   auto is_invalid_keycode{true};
   switch (toupper(c)) {
@@ -267,7 +267,7 @@ bool continue_playing_game(std::istream &in_os) {
   return true;
 }
 
-wrapper_bool_gamestatus_t process_gameStatus(gamestatus_gameboard_t gsgb) {
+bool_gamestatus_t process_gameStatus(gamestatus_gameboard_t gsgb) {
   gamestatus_t gamestatus;
   GameBoard gb;
   std::tie(gamestatus, gb) = gsgb;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -41,19 +41,6 @@ std::string receive_input_player_name(std::istream &is) {
   return name;
 }
 
-ull load_game_best_score() {
-  using namespace Statistics;
-  total_game_stats_t stats;
-  bool stats_file_loaded{};
-  ull tempscore{0};
-  std::tie(stats_file_loaded, stats) =
-      loadFromFileStatistics("../data/statistics.txt");
-  if (stats_file_loaded) {
-    tempscore = stats.bestScore;
-  }
-  return tempscore;
-}
-
 gamestatus_t process_gamelogic(gamestatus_t gamestatus) {
   unblockTilesOnGameboard(gamePlayBoard);
   if (gamePlayBoard.moved) {
@@ -390,7 +377,7 @@ void DoPostGameSaveStuff(double duration) {
 } // namespace
 
 void playGame(PlayGameFlag cont, GameBoard gb, ull userInput_PlaySize) {
-  bestScore = load_game_best_score();
+  bestScore = Statistics::load_game_best_score();
   gamePlayBoard = gb;
   if (cont == PlayGameFlag::BrandNewGame) {
     gamePlayBoard = GameBoard(userInput_PlaySize);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -89,14 +89,16 @@ std::string DisplayGameQuestionsToPlayerPrompt(gamestatus_t gamestatus) {
 
 // NOTE: current_game_session_t : (bestScore, gamestatus, gamePlayBoard)
 using current_game_session_t = std::tuple<ull, gamestatus_t, GameBoard>;
+enum tuple_cgs_t_idx { IDX_BESTSCORE, IDX_GAMESTATUS, IDX_GAMEBOARD };
+
 std::string drawGraphics(current_game_session_t cgs) {
   // Graphical Output has a specific ordering...
   using namespace Graphics;
   using namespace Gameboard::Graphics;
-  enum tuple_idx { IDX_BESTSCORE, IDX_GAMESTATUS, IDX_GAMEBOARD };
-  const auto bestScore = std::get<IDX_BESTSCORE>(cgs);
-  const auto gb = std::get<IDX_GAMEBOARD>(cgs);
-  const auto gamestatus = std::get<IDX_GAMESTATUS>(cgs);
+  using tup_idx = tuple_cgs_t_idx;
+  const auto bestScore = std::get<tup_idx::IDX_BESTSCORE>(cgs);
+  const auto gb = std::get<tup_idx::IDX_GAMEBOARD>(cgs);
+  const auto gamestatus = std::get<tup_idx::IDX_GAMESTATUS>(cgs);
 
   std::ostringstream str_os;
 
@@ -287,9 +289,10 @@ wrapper_bool_gamestatus_t process_gameStatus(gamestatus_gameboard_t gsgb) {
 using bool_current_game_session_t = std::tuple<bool, current_game_session_t>;
 bool_current_game_session_t soloGameLoop(current_game_session_t cgs) {
   using namespace Input;
-  enum tuple_idx { IDX_BESTSCORE, IDX_GAMESTATUS, IDX_GAMEBOARD };
-  const auto gamestatus = std::addressof(std::get<IDX_GAMESTATUS>(cgs));
-  const auto gb = std::addressof(std::get<IDX_GAMEBOARD>(cgs));
+  using tup_idx = tuple_cgs_t_idx;
+  const auto gamestatus =
+      std::addressof(std::get<tup_idx::IDX_GAMESTATUS>(cgs));
+  const auto gb = std::addressof(std::get<tup_idx::IDX_GAMEBOARD>(cgs));
 
   std::tie(*gamestatus, *gb) =
       process_gamelogic(std::make_tuple(*gamestatus, *gb));
@@ -318,10 +321,11 @@ std::string drawEndGameLoopGraphics(current_game_session_t finalgamestatus) {
   // Graphical Output has a specific ordering...
   using namespace Graphics;
   using namespace Gameboard::Graphics;
-  enum tuple_idx { IDX_BESTSCORE, IDX_GAMESTATUS, IDX_GAMEBOARD };
-  const auto bestScore = std::get<IDX_BESTSCORE>(finalgamestatus);
-  const auto gb = std::get<IDX_GAMEBOARD>(finalgamestatus);
-  const auto end_gamestatus = std::get<IDX_GAMESTATUS>(finalgamestatus);
+  using tup_idx = tuple_cgs_t_idx;
+  const auto bestScore = std::get<tup_idx::IDX_BESTSCORE>(finalgamestatus);
+  const auto gb = std::get<tup_idx::IDX_GAMEBOARD>(finalgamestatus);
+  const auto end_gamestatus =
+      std::get<tup_idx::IDX_GAMESTATUS>(finalgamestatus);
 
   std::ostringstream str_os;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -309,10 +309,6 @@ void endlessGameLoop() {
              DataSuppliment(world_gamestatus, drawEndGameLoopGraphics));
 }
 
-void saveScore(Scoreboard::Score finalscore) {
-  Scoreboard::saveToFileScore("../data/scores.txt", finalscore);
-}
-
 Graphics::finalscore_display_data_t
 make_finalscore_display_data(Scoreboard::Score finalscore) {
   const auto fsdd = std::make_tuple(
@@ -340,7 +336,7 @@ void DoPostGameSaveStuff(double duration) {
     const auto name = receive_input_player_name(std::cin);
     finalscore.name = name;
 
-    saveScore(finalscore);
+    Scoreboard::saveScore(finalscore);
     DrawAlways(std::cout, Graphics::MessageScoreSavedPrompt);
   }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -379,8 +379,9 @@ void DoPostGameSaveStuff(Scoreboard::Score finalscore, GameBoard gb) {
 } // namespace
 
 void playGame(PlayGameFlag cont, GameBoard gb, ull userInput_PlaySize) {
+  const auto is_this_a_new_game = (cont == PlayGameFlag::BrandNewGame);
   auto bestScore = Statistics::load_game_best_score();
-  if (cont == PlayGameFlag::BrandNewGame) {
+  if (is_this_a_new_game) {
     gb = GameBoard(userInput_PlaySize);
     addTileOnGameboard(gb);
   }
@@ -391,7 +392,7 @@ void playGame(PlayGameFlag cont, GameBoard gb, ull userInput_PlaySize) {
   const std::chrono::duration<double> elapsed = finishTime - startTime;
   const auto duration = elapsed.count();
 
-  if (cont == PlayGameFlag::BrandNewGame) {
+  if (is_this_a_new_game) {
     const auto finalscore = make_finalscore_from_game_session(duration, gb);
     DoPostGameSaveStuff(finalscore, gb);
   }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -389,7 +389,8 @@ Scoreboard::Score make_finalscore_from_game_session(double duration,
 
 void DoPostGameSaveStuff(Scoreboard::Score finalscore, competition_mode_t cm) {
   if (cm) {
-    Statistics::CreateFinalScoreAndEndGameDataFile(finalscore);
+    Statistics::CreateFinalScoreAndEndGameDataFile(std::cout, std::cin,
+                                                   finalscore);
   }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -35,12 +35,6 @@ using gamestatus_t = std::array<bool, MAX_NO_GAME_STATUS_FLAGS>;
 ull bestScore;
 GameBoard gamePlayBoard;
 
-std::string receive_input_player_name(std::istream &is) {
-  std::string name;
-  is >> name;
-  return name;
-}
-
 gamestatus_t process_gamelogic(gamestatus_t gamestatus) {
   unblockTilesOnGameboard(gamePlayBoard);
   if (gamePlayBoard.moved) {
@@ -320,28 +314,9 @@ Scoreboard::Score make_finalscore_from_game_session(double duration,
   return finalscore;
 }
 
-Graphics::finalscore_display_data_t
-make_finalscore_display_data(Scoreboard::Score finalscore) {
-  const auto fsdd = std::make_tuple(
-      std::to_string(finalscore.score), std::to_string(finalscore.largestTile),
-      std::to_string(finalscore.moveCount), secondsFormat(finalscore.duration));
-  return fsdd;
-};
-
 void DoPostGameSaveStuff(Scoreboard::Score finalscore) {
   if (std::get<0>(gamePlayBoard.gbda) == COMPETITION_GAME_BOARD_PLAY_SIZE) {
-    const auto finalscore_display_data =
-        make_finalscore_display_data(finalscore);
-    DrawAlways(std::cout, DataSuppliment(finalscore_display_data,
-                                         Graphics::EndGameStatisticsPrompt));
-    Statistics::saveEndGameStats(finalscore);
-
-    DrawAlways(std::cout, Graphics::AskForPlayerNamePrompt);
-    const auto name = receive_input_player_name(std::cin);
-    finalscore.name = name;
-
-    Scoreboard::saveScore(finalscore);
-    DrawAlways(std::cout, Graphics::MessageScoreSavedPrompt);
+    Statistics::CreateFinalScoreAndEndGameDataFile(finalscore);
   }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -263,21 +263,22 @@ wrapper_bool_current_game_session_t
 soloGameLoop(current_game_session_t currentgamesession) {
   using namespace Input;
   constexpr auto TUPLE_IDX_GAMESTATUS = 1;
+  const auto tuple_address_of_gamestatus =
+      std::addressof(std::get<TUPLE_IDX_GAMESTATUS>(currentgamesession));
   intendedmove_t player_intendedmove{};
 
-  gamestatus_t gamestatus = std::get<TUPLE_IDX_GAMESTATUS>(currentgamesession);
-  std::get<TUPLE_IDX_GAMESTATUS>(currentgamesession) =
-      process_gamelogic(gamestatus);
+  gamestatus_t gamestatus = *tuple_address_of_gamestatus;
+  *tuple_address_of_gamestatus = process_gamelogic(gamestatus);
   currentgamesession = drawGraphics(std::cout, currentgamesession);
 
-  gamestatus = std::get<TUPLE_IDX_GAMESTATUS>(currentgamesession);
+  gamestatus = *tuple_address_of_gamestatus;
   gamestatus = receive_agent_input(player_intendedmove, gamestatus);
 
   process_agent_input(player_intendedmove);
 
   bool loop_again;
   std::tie(loop_again, gamestatus) = process_gameStatus(gamestatus);
-  std::get<TUPLE_IDX_GAMESTATUS>(currentgamesession) = gamestatus;
+  *tuple_address_of_gamestatus = gamestatus;
   return std::make_tuple(loop_again, currentgamesession);
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -309,23 +309,6 @@ void endlessGameLoop() {
              DataSuppliment(world_gamestatus, drawEndGameLoopGraphics));
 }
 
-void saveEndGameStats(Scoreboard::Score finalscore) {
-  using namespace Statistics;
-  total_game_stats_t stats;
-  // Need some sort of stats data values only.
-  // No need to care if file loaded successfully or not...
-  std::tie(std::ignore, stats) =
-      loadFromFileStatistics("../data/statistics.txt");
-  stats.bestScore =
-      stats.bestScore < finalscore.score ? finalscore.score : stats.bestScore;
-  stats.gameCount++;
-  stats.winCount = finalscore.win ? stats.winCount + 1 : stats.winCount;
-  stats.totalMoveCount += finalscore.moveCount;
-  stats.totalDuration += finalscore.duration;
-
-  saveToFileEndGameStatistics("../data/statistics.txt", stats);
-}
-
 void saveScore(Scoreboard::Score finalscore) {
   Scoreboard::saveToFileScore("../data/scores.txt", finalscore);
 }
@@ -351,7 +334,7 @@ void DoPostGameSaveStuff(double duration) {
         make_finalscore_display_data(finalscore);
     DrawAlways(std::cout, DataSuppliment(finalscore_display_data,
                                          Graphics::EndGameStatisticsPrompt));
-    saveEndGameStats(finalscore);
+    Statistics::saveEndGameStats(finalscore);
 
     DrawAlways(std::cout, Graphics::AskForPlayerNamePrompt);
     const auto name = receive_input_player_name(std::cin);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -309,6 +309,17 @@ void endlessGameLoop() {
              DataSuppliment(world_gamestatus, drawEndGameLoopGraphics));
 }
 
+Scoreboard::Score make_finalscore_from_game_session(double duration,
+                                                    GameBoard gb) {
+  Scoreboard::Score finalscore{};
+  finalscore.score = gb.score;
+  finalscore.win = hasWonOnGameboard(gb);
+  finalscore.moveCount = MoveCountOnGameBoard(gb);
+  finalscore.largestTile = gb.largestTile;
+  finalscore.duration = duration;
+  return finalscore;
+}
+
 Graphics::finalscore_display_data_t
 make_finalscore_display_data(Scoreboard::Score finalscore) {
   const auto fsdd = std::make_tuple(
@@ -317,15 +328,8 @@ make_finalscore_display_data(Scoreboard::Score finalscore) {
   return fsdd;
 };
 
-void DoPostGameSaveStuff(double duration) {
+void DoPostGameSaveStuff(Scoreboard::Score finalscore) {
   if (std::get<0>(gamePlayBoard.gbda) == COMPETITION_GAME_BOARD_PLAY_SIZE) {
-    Scoreboard::Score finalscore{};
-    finalscore.score = gamePlayBoard.score;
-    finalscore.win = hasWonOnGameboard(gamePlayBoard);
-    finalscore.moveCount = MoveCountOnGameBoard(gamePlayBoard);
-    finalscore.largestTile = gamePlayBoard.largestTile;
-    finalscore.duration = duration;
-
     const auto finalscore_display_data =
         make_finalscore_display_data(finalscore);
     DrawAlways(std::cout, DataSuppliment(finalscore_display_data,
@@ -358,7 +362,9 @@ void playGame(PlayGameFlag cont, GameBoard gb, ull userInput_PlaySize) {
   const auto duration = elapsed.count();
 
   if (cont == PlayGameFlag::BrandNewGame) {
-    DoPostGameSaveStuff(duration);
+    const auto finalscore =
+        make_finalscore_from_game_session(duration, gamePlayBoard);
+    DoPostGameSaveStuff(finalscore);
   }
 }
 

--- a/src/headers/game-graphics.hpp
+++ b/src/headers/game-graphics.hpp
@@ -13,8 +13,6 @@ enum { COMPETITION_GAME_BOARD_PLAY_SIZE = 4 };
 namespace Game {
 namespace Graphics {
 std::string AsciiArt2048();
-std::string MessageScoreSavedPrompt();
-std::string AskForPlayerNamePrompt();
 std::string BoardInputPrompt();
 std::string YouWinPrompt();
 std::string GameOverPrompt();
@@ -27,9 +25,6 @@ std::string BoardSizeErrorPrompt();
 std::string InputCommandListPrompt();
 std::string EndlessModeCommandListPrompt();
 std::string InputCommandListFooterPrompt();
-using finalscore_display_data_t =
-    std::tuple<std::string, std::string, std::string, std::string>;
-std::string EndGameStatisticsPrompt(finalscore_display_data_t finalscore);
 using scoreboard_display_data_t =
     std::tuple<bool, std::string, std::string, std::string>;
 std::string GameScoreBoardBox(scoreboard_display_data_t scdd);

--- a/src/headers/saveresource.hpp
+++ b/src/headers/saveresource.hpp
@@ -8,9 +8,7 @@ namespace Game {
 struct GameBoard;
 
 namespace Saver {
-void saveToFilePreviousGameStateData(std::string filename, const GameBoard &gb);
-void saveToFilePreviousGameStatisticsData(std::string filename,
-                                          const GameBoard &gb);
+void saveGamePlayState(GameBoard gb);
 } // namespace Saver
 } // namespace Game
 

--- a/src/headers/scores-graphics.hpp
+++ b/src/headers/scores-graphics.hpp
@@ -12,6 +12,10 @@ using scoreboard_display_data_t =
 
 using scoreboard_display_data_list_t = std::vector<scoreboard_display_data_t>;
 std::string ScoreboardOverlay(scoreboard_display_data_list_t sbddl);
+
+using finalscore_display_data_t =
+    std::tuple<std::string, std::string, std::string, std::string>;
+std::string EndGameStatisticsPrompt(finalscore_display_data_t finalscore);
 } // namespace Graphics
 } // namespace Scoreboard
 

--- a/src/headers/scores.hpp
+++ b/src/headers/scores.hpp
@@ -25,7 +25,7 @@ using load_score_status_t = std::tuple<bool, Scoreboard_t>;
 // List of scores read until "exhausted".
 // Note: returns a tuple containing a std::vector<Score> of all read scores.
 load_score_status_t loadFromFileScore(std::string filename);
-bool saveToFileScore(std::string filename, Score s);
+void saveScore(Score finalscore);
 } // namespace Scoreboard
 
 std::istream &operator>>(std::istream &is, Scoreboard::Score &s);

--- a/src/headers/statistics-graphics.hpp
+++ b/src/headers/statistics-graphics.hpp
@@ -6,6 +6,9 @@
 
 namespace Statistics {
 namespace Graphics {
+std::string AskForPlayerNamePrompt();
+std::string MessageScoreSavedPrompt();
+
 using total_stats_display_data_t =
     std::tuple<bool, std::string, std::string, std::string, std::string,
                std::string>;

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -24,7 +24,8 @@ using load_stats_status_t = std::tuple<bool, total_game_stats_t>;
 load_stats_status_t loadFromFileStatistics(std::string filename);
 ull load_game_best_score();
 void saveEndGameStats(Scoreboard::Score finalscore);
-void CreateFinalScoreAndEndGameDataFile(Scoreboard::Score finalscore);
+void CreateFinalScoreAndEndGameDataFile(std::ostream &os, std::istream &is,
+                                        Scoreboard::Score finalscore);
 } // namespace Statistics
 
 std::istream &operator>>(std::istream &is, Statistics::total_game_stats_t &s);

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -19,6 +19,7 @@ using load_stats_status_t = std::tuple<bool, total_game_stats_t>;
 
 load_stats_status_t loadFromFileStatistics(std::string filename);
 bool saveToFileEndGameStatistics(std::string filename, total_game_stats_t s);
+ull load_game_best_score();
 } // namespace Statistics
 
 std::istream &operator>>(std::istream &is, Statistics::total_game_stats_t &s);

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -6,6 +6,10 @@
 #include <string>
 #include <tuple>
 
+namespace Scoreboard {
+struct Score;
+}
+
 namespace Statistics {
 struct total_game_stats_t {
   ull bestScore{};
@@ -18,8 +22,8 @@ struct total_game_stats_t {
 using load_stats_status_t = std::tuple<bool, total_game_stats_t>;
 
 load_stats_status_t loadFromFileStatistics(std::string filename);
-bool saveToFileEndGameStatistics(std::string filename, total_game_stats_t s);
 ull load_game_best_score();
+void saveEndGameStats(Scoreboard::Score finalscore);
 } // namespace Statistics
 
 std::istream &operator>>(std::istream &is, Statistics::total_game_stats_t &s);

--- a/src/headers/statistics.hpp
+++ b/src/headers/statistics.hpp
@@ -24,6 +24,7 @@ using load_stats_status_t = std::tuple<bool, total_game_stats_t>;
 load_stats_status_t loadFromFileStatistics(std::string filename);
 ull load_game_best_score();
 void saveEndGameStats(Scoreboard::Score finalscore);
+void CreateFinalScoreAndEndGameDataFile(Scoreboard::Score finalscore);
 } // namespace Statistics
 
 std::istream &operator>>(std::istream &is, Statistics::total_game_stats_t &s);

--- a/src/saveresource.cpp
+++ b/src/saveresource.cpp
@@ -18,8 +18,6 @@ bool generateFilefromPreviousGameStateData(std::ostream &os,
   return true;
 }
 
-} // namespace
-
 void saveToFilePreviousGameStateData(std::string filename,
                                      const GameBoard &gb) {
   std::ofstream stateFile(filename, std::ios_base::app);
@@ -31,5 +29,20 @@ void saveToFilePreviousGameStatisticsData(std::string filename,
   std::ofstream stats(filename, std::ios_base::app);
   generateFilefromPreviousGameStatisticsData(stats, gb);
 }
+
+} // namespace
+
+void saveGamePlayState(GameBoard gb) {
+  // Currently two datafiles for now.
+  // Will be merged into one datafile in a future PR.
+  constexpr auto filename_game_data_state = "../data/previousGame";
+  constexpr auto filename_game_data_statistics = "../data/previousGameStats";
+  std::remove(filename_game_data_state);
+  std::remove(filename_game_data_statistics);
+
+  saveToFilePreviousGameStateData(filename_game_data_state, gb);
+  saveToFilePreviousGameStatisticsData(filename_game_data_statistics, gb);
+}
+
 } // namespace Saver
 } // namespace Game

--- a/src/scores-graphics.cpp
+++ b/src/scores-graphics.cpp
@@ -66,6 +66,49 @@ std::string ScoreboardOverlay(scoreboard_display_data_list_t sbddl) {
   return str_os.str();
 }
 
+std::string EndGameStatisticsPrompt(finalscore_display_data_t finalscore) {
+  std::ostringstream str_os;
+  constexpr auto stats_title_text = "STATISTICS";
+  constexpr auto divider_text = "──────────";
+  constexpr auto sp = "  ";
+  const auto stats_attributes_text = {
+      "Final score:", "Largest Tile:", "Number of moves:", "Time taken:"};
+  enum FinalScoreDisplayDataFields {
+    IDX_FINAL_SCORE_VALUE,
+    IDX_LARGEST_TILE,
+    IDX_MOVE_COUNT,
+    IDX_DURATION,
+    MAX_NUM_OF_FINALSCOREDISPLAYDATA_INDEXES
+  };
+  const auto data_stats =
+      std::array<std::string, MAX_NUM_OF_FINALSCOREDISPLAYDATA_INDEXES>{
+          std::get<IDX_FINAL_SCORE_VALUE>(finalscore),
+          std::get<IDX_LARGEST_TILE>(finalscore),
+          std::get<IDX_MOVE_COUNT>(finalscore),
+          std::get<IDX_DURATION>(finalscore)};
+
+  std::ostringstream stats_richtext;
+  stats_richtext << yellow << sp << stats_title_text << def << "\n";
+  stats_richtext << yellow << sp << divider_text << def << "\n";
+
+  auto counter{0};
+  const auto populate_stats_info = [data_stats, stats_attributes_text, &counter,
+                                    &stats_richtext](const std::string) {
+    stats_richtext << sp << std::left << std::setw(19)
+                   << std::begin(stats_attributes_text)[counter] << bold_on
+                   << std::begin(data_stats)[counter] << bold_off << "\n";
+    counter++;
+  };
+
+  for (const auto s : stats_attributes_text) {
+    populate_stats_info(s);
+  }
+
+  str_os << stats_richtext.str();
+  str_os << "\n\n";
+  return str_os.str();
+}
+
 } // namespace Graphics
 
 } // namespace Scoreboard

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -20,9 +20,19 @@ Scoreboard_t generateScorefromFileData(std::istream &is) {
   };
   return scoreList;
 }
+
+bool saveToFileScore(std::string filename, Score s) {
+  std::ofstream os(filename, std::ios_base::app);
+  return generateFilefromScoreData(os, s);
+}
+
 } // namespace
 
 namespace Scoreboard {
+bool operator>(const Score &a, const Score &b) {
+  return a.score > b.score;
+}
+
 load_score_status_t loadFromFileScore(std::string filename) {
   std::ifstream scores(filename);
   if (scores) {
@@ -34,13 +44,8 @@ load_score_status_t loadFromFileScore(std::string filename) {
   return load_score_status_t{false, Scoreboard_t{}};
 }
 
-bool saveToFileScore(std::string filename, Score s) {
-  std::ofstream os(filename, std::ios_base::app);
-  return generateFilefromScoreData(os, s);
-}
-
-bool operator>(const Score &a, const Score &b) {
-  return a.score > b.score;
+void saveScore(Score finalscore) {
+  saveToFileScore("../data/scores.txt", finalscore);
 }
 
 } // namespace Scoreboard

--- a/src/statistics-graphics.cpp
+++ b/src/statistics-graphics.cpp
@@ -7,6 +7,25 @@
 namespace Statistics {
 namespace Graphics {
 
+std::string AskForPlayerNamePrompt() {
+  constexpr auto score_prompt_text =
+      "Please enter your name to save this score: ";
+  constexpr auto sp = "  ";
+  std::ostringstream score_prompt_richtext;
+  score_prompt_richtext << bold_on << sp << score_prompt_text << bold_off;
+  return score_prompt_richtext.str();
+}
+
+std::string MessageScoreSavedPrompt() {
+  constexpr auto score_saved_text = "Score saved!";
+  constexpr auto sp = "  ";
+  std::ostringstream score_saved_richtext;
+  score_saved_richtext << "\n"
+                       << green << bold_on << sp << score_saved_text << bold_off
+                       << def << "\n";
+  return score_saved_richtext.str();
+}
+
 std::string TotalStatisticsOverlay(total_stats_display_data_t tsdd) {
   constexpr auto stats_title_text = "STATISTICS";
   constexpr auto divider_text = "──────────";

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -1,14 +1,23 @@
 #include "statistics.hpp"
 #include "color.hpp"
+#include "scores-graphics.hpp"
 #include "scores.hpp"
+#include "statistics-graphics.hpp"
 #include <algorithm>
 #include <array>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 
 namespace Statistics {
 
 namespace {
+
+std::string receive_input_player_name(std::istream &is) {
+  std::string name;
+  is >> name;
+  return name;
+}
 
 total_game_stats_t generateStatsFromInputData(std::istream &is) {
   total_game_stats_t stats;
@@ -25,6 +34,14 @@ bool saveToFileEndGameStatistics(std::string filename, total_game_stats_t s) {
   std::ofstream filedata(filename);
   return generateFilefromStatsData(filedata, s);
 }
+
+Scoreboard::Graphics::finalscore_display_data_t
+make_finalscore_display_data(Scoreboard::Score finalscore) {
+  const auto fsdd = std::make_tuple(
+      std::to_string(finalscore.score), std::to_string(finalscore.largestTile),
+      std::to_string(finalscore.moveCount), secondsFormat(finalscore.duration));
+  return fsdd;
+};
 
 } // namespace
 
@@ -63,6 +80,21 @@ void saveEndGameStats(Scoreboard::Score finalscore) {
   stats.totalDuration += finalscore.duration;
 
   saveToFileEndGameStatistics("../data/statistics.txt", stats);
+}
+
+void CreateFinalScoreAndEndGameDataFile(Scoreboard::Score finalscore) {
+  const auto finalscore_display_data = make_finalscore_display_data(finalscore);
+  DrawAlways(std::cout,
+             DataSuppliment(finalscore_display_data,
+                            Scoreboard::Graphics::EndGameStatisticsPrompt));
+  Statistics::saveEndGameStats(finalscore);
+
+  DrawAlways(std::cout, Graphics::AskForPlayerNamePrompt);
+  const auto name = receive_input_player_name(std::cin);
+  finalscore.name = name;
+
+  Scoreboard::saveScore(finalscore);
+  DrawAlways(std::cout, Graphics::MessageScoreSavedPrompt);
 }
 
 } // namespace Statistics

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -1,5 +1,6 @@
 #include "statistics.hpp"
 #include "color.hpp"
+#include "scores.hpp"
 #include <algorithm>
 #include <array>
 #include <fstream>
@@ -20,6 +21,11 @@ bool generateFilefromStatsData(std::ostream &os, total_game_stats_t stats) {
   return true;
 }
 
+bool saveToFileEndGameStatistics(std::string filename, total_game_stats_t s) {
+  std::ofstream filedata(filename);
+  return generateFilefromStatsData(filedata, s);
+}
+
 } // namespace
 
 load_stats_status_t loadFromFileStatistics(std::string filename) {
@@ -29,11 +35,6 @@ load_stats_status_t loadFromFileStatistics(std::string filename) {
     return load_stats_status_t{true, stats};
   }
   return load_stats_status_t{false, total_game_stats_t{}};
-}
-
-bool saveToFileEndGameStatistics(std::string filename, total_game_stats_t s) {
-  std::ofstream filedata(filename);
-  return generateFilefromStatsData(filedata, s);
 }
 
 ull load_game_best_score() {
@@ -46,6 +47,22 @@ ull load_game_best_score() {
     tempscore = stats.bestScore;
   }
   return tempscore;
+}
+
+void saveEndGameStats(Scoreboard::Score finalscore) {
+  total_game_stats_t stats;
+  // Need some sort of stats data values only.
+  // No need to care if file loaded successfully or not...
+  std::tie(std::ignore, stats) =
+      loadFromFileStatistics("../data/statistics.txt");
+  stats.bestScore =
+      stats.bestScore < finalscore.score ? finalscore.score : stats.bestScore;
+  stats.gameCount++;
+  stats.winCount = finalscore.win ? stats.winCount + 1 : stats.winCount;
+  stats.totalMoveCount += finalscore.moveCount;
+  stats.totalDuration += finalscore.duration;
+
+  saveToFileEndGameStatistics("../data/statistics.txt", stats);
 }
 
 } // namespace Statistics

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -36,6 +36,18 @@ bool saveToFileEndGameStatistics(std::string filename, total_game_stats_t s) {
   return generateFilefromStatsData(filedata, s);
 }
 
+ull load_game_best_score() {
+  total_game_stats_t stats;
+  bool stats_file_loaded{};
+  ull tempscore{0};
+  std::tie(stats_file_loaded, stats) =
+      loadFromFileStatistics("../data/statistics.txt");
+  if (stats_file_loaded) {
+    tempscore = stats.bestScore;
+  }
+  return tempscore;
+}
+
 } // namespace Statistics
 
 using namespace Statistics;

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <fstream>
-#include <iostream>
 #include <sstream>
 
 namespace Statistics {
@@ -82,19 +81,19 @@ void saveEndGameStats(Scoreboard::Score finalscore) {
   saveToFileEndGameStatistics("../data/statistics.txt", stats);
 }
 
-void CreateFinalScoreAndEndGameDataFile(Scoreboard::Score finalscore) {
+void CreateFinalScoreAndEndGameDataFile(std::ostream &os, std::istream &is,
+                                        Scoreboard::Score finalscore) {
   const auto finalscore_display_data = make_finalscore_display_data(finalscore);
-  DrawAlways(std::cout,
-             DataSuppliment(finalscore_display_data,
-                            Scoreboard::Graphics::EndGameStatisticsPrompt));
-  Statistics::saveEndGameStats(finalscore);
+  DrawAlways(os, DataSuppliment(finalscore_display_data,
+                                Scoreboard::Graphics::EndGameStatisticsPrompt));
 
-  DrawAlways(std::cout, Graphics::AskForPlayerNamePrompt);
-  const auto name = receive_input_player_name(std::cin);
+  DrawAlways(os, Graphics::AskForPlayerNamePrompt);
+  const auto name = receive_input_player_name(is);
   finalscore.name = name;
 
   Scoreboard::saveScore(finalscore);
-  DrawAlways(std::cout, Graphics::MessageScoreSavedPrompt);
+  saveEndGameStats(finalscore);
+  DrawAlways(os, Graphics::MessageScoreSavedPrompt);
 }
 
 } // namespace Statistics


### PR DESCRIPTION
Summary:
* Removed `bestScore` from global TU namespace.
* Removed `gamePlayBoard` from global TU namespace.
* Removed "in-out" parameter variables from functions.
* Moved some functions from Game TU to more appropriate TUs.
* Added more descriptive custom-named definitions for helper tuple datatypes.
* Reduced even more dependency on `std::c{in, out}`.
* "Graphical output" functions are refactored to minimise "functional side-effects" (i.e. now only outputs one `std::string` datatype result; accepts only one "in"-type parameter).