### PR TITLE
Fix: Travis: Build 266.2: Missing includes for Scores-Graphics TU

### DIFF
--- a/src/headers/scores-graphics.hpp
+++ b/src/headers/scores-graphics.hpp
@@ -2,6 +2,7 @@
 #define SCORESGRAPHICS_H
 
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace Scoreboard {

--- a/src/scores-graphics.cpp
+++ b/src/scores-graphics.cpp
@@ -1,5 +1,6 @@
 #include "scores-graphics.hpp"
 #include "color.hpp"
+#include <array>
 #include <iomanip>
 #include <sstream>
 


### PR DESCRIPTION
* Travis build: 266.2 failed because of missing includes for std::{array, tuple}.