### PR TITLE
Docs: Add "run on repl.it" badge

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "cd build && cmake ../ && cmake --build . && ./2048"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/b37414d66e7d4146bf72a4a467fdc84d)](https://app.codacy.com/app/plibither8/2048.cpp?utm_source=github.com&utm_medium=referral&utm_content=plibither8/2048.cpp&utm_campaign=Badge_Grade_Dashboard)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/plibither8/2048.cpp.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/plibither8/2048.cpp/context:cpp)
 [![Made with Love in India](https://madewithlove.org.in/badge.svg)](https://madewithlove.org.in/)
+[![Run on Repl.it](https://repl.it/badge/github/plibither8/2048.cpp)](https://repl.it/github/plibither8/2048.cpp)
 
 > Terminal version of the game "2048" written in C++.
 


### PR DESCRIPTION
Really cool implementation! 

I think it would be awesome if users could try the game (and even improve and commit to it) from the browser. Would you consider adding a "run on repl.it" badge? 

Here is how it will look like!
<img width="1360" alt="Screen Shot 2019-12-08 at 8 03 51 PM" src="https://user-images.githubusercontent.com/587518/70406560-0719c500-19f6-11ea-9854-b1f1f3e3ede1.png">


You can try it here: https://repl.it/@amasad/2048-cpp