### PR TITLE
CMake corrections: datadir, minimum CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,10 @@
-cmake_minimum_required(VERSION 3.7...3.21)
+cmake_minimum_required(VERSION 3.14...3.24)
 project(2048 LANGUAGES CXX)
 enable_testing()
 
 set(SOURCES src/2048.cpp src/gameboard.cpp src/gameboard-graphics.cpp src/game.cpp src/game-graphics.cpp src/game-input.cpp src/game-pregamemenu.cpp src/global.cpp src/loadresource.cpp src/menu.cpp src/menu-graphics.cpp src/saveresource.cpp src/scores.cpp src/scores-graphics.cpp src/statistics.cpp src/statistics-graphics.cpp src/tile.cpp src/tile-graphics.cpp)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-  add_compile_options(-Wall)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   add_compile_options(-Wall)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "^Intel")
   if(WIN32)
@@ -14,7 +12,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "^Intel")
   else()
     add_compile_options(-w2)
   endif()
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL NVHPC)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
   add_compile_options(-a)
 endif()
 
@@ -33,8 +31,8 @@ endif()
 
 # --- install
 
-install(TARGETS 2048
-  RUNTIME DESTINATION bin)
+install(TARGETS 2048)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data
-        DESTINATION ${CMAKE_INSTALL_PREFIX})
+DESTINATION ${CMAKE_INSTALL_PREFIX}/data
+)

--- a/setup.cmake
+++ b/setup.cmake
@@ -11,18 +11,11 @@ set(_opts)
 if(NOT DEFINED CTEST_CMAKE_GENERATOR AND DEFINED ENV{CMAKE_GENERATOR})
   set(CTEST_CMAKE_GENERATOR $ENV{CMAKE_GENERATOR})
 endif()
-if(NOT DEFINED CTEST_CMAKE_GENERATOR AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+if(NOT DEFINED CTEST_CMAKE_GENERATOR)
   find_program(_gen NAMES ninja ninja-build samu)
   if(_gen)
-    execute_process(COMMAND ${_gen} --version
-      OUTPUT_VARIABLE _ninja_version
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      RESULT_VARIABLE _gen_ok
-      TIMEOUT 10)
-    if(_gen_ok EQUAL 0 AND _ninja_version VERSION_GREATER_EQUAL 1.10)
-      set(CTEST_CMAKE_GENERATOR "Ninja")
-    endif()
-  endif(_gen)
+    set(CTEST_CMAKE_GENERATOR "Ninja")
+  endif()
 endif()
 if(NOT DEFINED CTEST_CMAKE_GENERATOR)
   set(CTEST_BUILD_FLAGS -j)  # not --parallel as this goes to generator directly


### PR DESCRIPTION
CMake 3.7 didn't actually work with the project configuration.
Put CMake 3.14 (and tested) as a reasonable minimum CMake.

Corrected data install directory.

Corrected compiler option selection.