### PR TITLE
gameboard.hpp: don't redefine class point2D_t as struct

### DIFF
--- a/src/headers/gameboard.hpp
+++ b/src/headers/gameboard.hpp
@@ -1,11 +1,10 @@
 #ifndef GAMEBOARD_H
 #define GAMEBOARD_H
 
+#include "point2d.hpp"
 #include "tile.hpp"
 #include <tuple>
 #include <vector>
-
-struct point2D_t;
 
 namespace Game {
 


### PR DESCRIPTION
It seems that gameboard.hpp should include point2d.hpp instead of redefining point2d_t as a struct instead of a class